### PR TITLE
Added PNC (punctuation and capitalization) flag for NeMo ASR model inference

### DIFF
--- a/nemo_asr/run_canary.sh
+++ b/nemo_asr/run_canary.sh
@@ -3,6 +3,7 @@
 export PYTHONPATH="..":$PYTHONPATH
 
 MODEL_IDs=("nvidia/canary-1b")
+PNC=False
 BATCH_SIZE=64
 DEVICE_ID=0
 
@@ -19,6 +20,7 @@ do
         --dataset="ami" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
     
@@ -28,6 +30,7 @@ do
         --dataset="earnings22" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -37,6 +40,7 @@ do
         --dataset="gigaspeech" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -46,6 +50,7 @@ do
         --dataset="librispeech" \
         --split="test.clean" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -55,6 +60,7 @@ do
         --dataset="librispeech" \
         --split="test.other" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -64,6 +70,7 @@ do
         --dataset="spgispeech" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -73,6 +80,7 @@ do
         --dataset="tedlium" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -82,6 +90,7 @@ do
         --dataset="voxpopuli" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 
@@ -91,6 +100,7 @@ do
         --dataset="common_voice" \
         --split="test" \
         --device=${DEVICE_ID} \
+        --pnc=${PNC} \
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1 
 


### PR DESCRIPTION
**What this PR does:** Adds a flag for specifying PnC mode (output with punctuation and capitalization) for NeMo ASR model inference.

**Why is it required:** The default mode for NeMo Canary inference is output with Punctuation and Capitalization, whereas the leaderboard numbers are reported with pnc mode turned off. This causes a mismatch in the reported numbers and the numbers obtained from current eval script. 
For e.g., for Librispeech-test-clean, the current version of the eval script gives a WER of 1.56% which is inconsistent with the reported numbers. With the provided fix (setting default Canary pnc inference to false), we get WER of 1.49%, as expected.  

