### PR TITLE
Use faster-whisper model names instead of hardcoded HF names

### DIFF
--- a/ctranslate2/calc_rtf.py
+++ b/ctranslate2/calc_rtf.py
@@ -7,12 +7,13 @@ device = "cuda"
 device_index = 0
 
 models = [
-    "guillaumekln/faster-whisper-tiny.en",
-    "guillaumekln/faster-whisper-small.en",
-    "guillaumekln/faster-whisper-base.en",
-    "guillaumekln/faster-whisper-medium.en",
-    "guillaumekln/faster-whisper-large-v1",
-    "guillaumekln/faster-whisper-large-v2",
+    "tiny.en",
+    "small.en",
+    "base.en",
+    "medium.en",
+    "large-v1",
+    "large-v2",
+    "large-v3"
 ]
 
 n_batches = 3

--- a/ctranslate2/run_whisper.sh
+++ b/ctranslate2/run_whisper.sh
@@ -2,7 +2,7 @@
 
 export PYTHONPATH="..":$PYTHONPATH
 
-MODEL_IDs=("guillaumekln/faster-whisper-tiny.en" "guillaumekln/faster-whisper-small.en" "guillaumekln/faster-whisper-base.en" "guillaumekln/faster-whisper-medium.en" "guillaumekln/faster-whisper-large-v1" "guillaumekln/faster-whisper-large-v2")
+MODEL_IDs=("tiny.en" "small.en" "base.en" "medium.en" "large-v1" "large-v2" "large-v3")
 BATCH_SIZE=1
 DEVICE_INDEX=0
 


### PR DESCRIPTION
Use model names instead of hardcoded HF names.

Nowadays for example faster-whisper does not use guillaumekln/faster-whisper-tiny.en uses Systran/faster-whisper-tiny.en models since guillaumekln was associated to a personal account no longer active in the project.

Also adding large-v3 model.