### PR TITLE
Update Granite Speech results

### DIFF
--- a/granite/run_granite.sh
+++ b/granite/run_granite.sh
@@ -8,8 +8,8 @@ MODEL_IDs=(
 )
 
 BATCH_SIZEs=(
-    20 
-    12
+    160 
+    64
 )
 
 NUM_BEAMS=1


### PR DESCRIPTION
Hey @Deep-unlearning @nithinraok @Vaibhavs10,

# TL;DR
We have updated [granite-speech-3.3-2b](https://huggingface.co/ibm-granite/granite-speech-3.3-2b) and [granite-speech-3.3-8b](https://huggingface.co/ibm-granite/granite-speech-3.3-8b) models to revision 3.3.2. 
The new models achieve better results on the OpenASR leaderboard (claiming the first and second place) and have a better RTFx.
We've included the updated results when running on an A100 below.

# What changed
- We used a larger speech encoder, trained on multilingual data. 
- We have updated `modeling_granite_speech.py` to speed up training and inference time. See [this PR](https://github.com/huggingface/transformers/pull/39028) for additional details.
- In this codebase, we load the model in bfloat16 and increase the batch size to improve utilization. 

# Important note
There's a small issue in the model name formatting. 
Before you update the results, can you replace all instances of `ibm/granite-granite-speech` with `ibm-granite/granite-speech`? 🙏 .

Thank you very much!
Joint work with @gsaon 

```
********************************************************************************
Results per dataset:
********************************************************************************
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 8.90 %, RTFx = 232.84
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 10.25 %, RTFx = 173.39
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 10.69 %, RTFx = 235.82
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.53 %, RTFx = 265.95
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 3.26 %, RTFx = 251.83
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 3.87 %, RTFx = 310.51
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 3.57 %, RTFx = 208.98
ibm/granite-granite-speech-3.3-2b | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 5.93 %, RTFx = 193.45

********************************************************************************
Composite Results:
********************************************************************************
ibm/granite-granite-speech-3.3-2b: WER = 6.00 %
ibm/granite-granite-speech-3.3-2b: RTFx = 270.57
********************************************************************************

********************************************************************************
Results per dataset:
********************************************************************************
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 8.98 %, RTFx = 105.65
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 9.42 %, RTFx = 128.72
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 10.19 %, RTFx = 137.13
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.43 %, RTFx = 142.87
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 2.86 %, RTFx = 136.54
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 3.91 %, RTFx = 157.32
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 3.40 %, RTFx = 125.05
ibm/granite-granite-speech-3.3-8b | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 5.72 %, RTFx = 128.80

********************************************************************************
Composite Results:
********************************************************************************
ibm/granite-granite-speech-3.3-8b: WER = 5.74 %
ibm/granite-granite-speech-3.3-8b: RTFx = 145.42
********************************************************************************
```
