### PR TITLE
Adding shunyalabs/pingala-v1-en-verbatim on OpenASR leaderboard

### DIFF
--- a/ctranslate2/run_whisper.sh
+++ b/ctranslate2/run_whisper.sh
@@ -2,7 +2,7 @@
 
 export PYTHONPATH="..":$PYTHONPATH
 
-MODEL_IDs=("tiny.en" "small.en" "base.en" "medium.en" "large-v1" "large-v2" "large-v3")
+MODEL_IDs=("shunyalabs/pingala-v1-en-verbatim")
 DEVICE_INDEX=0
 
 num_models=${#MODEL_IDs[@]}


### PR DESCRIPTION
Hi @Vaibhavs10  we just released our model [shunyalabs/pingala-v1-en-verbatim](https://huggingface.co/shunyalabs/pingala-v1-en-verbatim) can you add our model to OpenASR leaderboard.

We have achieved this result on a L40 GPU. 

```
********************************************************************************
Results per dataset:
********************************************************************************
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 3.52 %, RTFx = 18.38
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 4.36 %, RTFx = 25.67
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 4.26 %, RTFx = 24.62
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.84 %, RTFx = 29.20
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 2.81 %, RTFx = 25.01
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 1.13 %, RTFx = 11.67
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 2.14 %, RTFx = 11.03
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 3.47 %, RTFx = 31.81

********************************************************************************
Composite Results:
********************************************************************************
shunyalabs/pingala-v1-en-verbatim: WER = 2.94 %
shunyalabs/pingala-v1-en-verbatim: RTFx = 14.61
********************************************************************************
```

Do let me know if anything is required, I'll be happy to contribute.