### PR TITLE
Adding Support for ShunyaLabs - Pingala V1 ASR models (shunyalabs/pingala-v1-en-verbatim, shunyalabs/pingala-v1-universal) on OpenASR Leaderboard

### DIFF
--- a/ctranslate2/run_pingala_shunyalabs.sh
+++ b/ctranslate2/run_pingala_shunyalabs.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+export PYTHONPATH="..":$PYTHONPATH
+
+MODEL_IDs=("shunyalabs/pingala-v1-en-verbatim")
+DEVICE_INDEX=0
+
+num_models=${#MODEL_IDs[@]}
+
+for (( i=0; i<${num_models}; i++ ));
+do
+    MODEL_ID=${MODEL_IDs[$i]}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="ami" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="earnings22" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="gigaspeech" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.clean" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.other" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="spgispeech" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="tedlium" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="voxpopuli" \
+        --split="test" \
+        --device=${DEVICE_INDEX} \
+        --max_eval_samples=-1
+
+    # Evaluate results
+    RUNDIR=`pwd` && \
+    cd ../normalizer && \
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+    cd $RUNDIR
+
+done

--- a/transformers/run_pingala_shunyalabs.sh
+++ b/transformers/run_pingala_shunyalabs.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+export PYTHONPATH="..":$PYTHONPATH
+
+MODEL_IDs=("shunyalabs/pingala-v1-universal")
+BATCH_SIZE=64
+
+num_models=${#MODEL_IDs[@]}
+
+for (( i=0; i<${num_models}; i++ ));
+do
+    MODEL_ID=${MODEL_IDs[$i]}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="voxpopuli" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="ami" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="earnings22" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="gigaspeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.clean" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.other" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="spgispeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="tedlium" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    # Evaluate results
+    RUNDIR=`pwd` && \
+    cd ../normalizer && \
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+    cd $RUNDIR
+
+done


### PR DESCRIPTION
Hi @Vaibhavs10  we just released our models [shunyalabs/pingala-v1-en-verbatim](https://huggingface.co/shunyalabs/pingala-v1-en-verbatim) and [shunyalabs/pingala-v1-universal](https://huggingface.co/shunyalabs/pingala-v1-universal) can you add our model to OpenASR leaderboard.

We have achieved this result on a L40 GPU. 

The  [shunyalabs/pingala-v1-en-verbatim](https://huggingface.co/shunyalabs/pingala-v1-en-verbatim) model is a ctranslate2 model, added this to the ctranslate2 section and the model [shunyalabs/pingala-v1-universal](https://huggingface.co/shunyalabs/pingala-v1-universal) is a transformer one, added the necessary files for evaluation.


Results for shunyalabs/pingala-v1-en-verbatim: 
```
********************************************************************************
Results per dataset:
********************************************************************************
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 3.52 %, RTFx = 18.38
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 4.36 %, RTFx = 25.67
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 4.26 %, RTFx = 24.62
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.84 %, RTFx = 29.20
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 2.81 %, RTFx = 25.01
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 1.13 %, RTFx = 11.67
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 2.14 %, RTFx = 11.03
shunyalabs/pingala-v1-en-verbatim | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 3.47 %, RTFx = 31.81

********************************************************************************
Composite Results:
********************************************************************************
shunyalabs/pingala-v1-en-verbatim: WER = 2.94 %
shunyalabs/pingala-v1-en-verbatim: RTFx = 14.61
********************************************************************************
```

Results for shunyalabs/pingala-v1-universal:

```
********************************************************************************
Results per dataset:
********************************************************************************
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 4.19 %, RTFx = 70.22
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 5.83 %, RTFx = 101.52
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 4.99 %, RTFx = 131.09
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 0.71 %, RTFx = 158.74
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 2.17 %, RTFx = 142.40
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 1.10 %, RTFx = 170.85
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 1.43 %, RTFx = 153.34
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 4.34 %, RTFx = 179.28

********************************************************************************
Composite Results:
********************************************************************************
shunyalabs/pingala-v1-universal: WER = 3.10 %
shunyalabs/pingala-v1-universal: RTFx = 146.23
********************************************************************************

```


Do let me know if anything is required, I'll be happy to contribute.