### PR TITLE
Add Whisper-based SOTA model (record-breaking WER) – 1-line change

### DIFF
--- a/transformers/run_whisper.sh
+++ b/transformers/run_whisper.sh
@@ -2,7 +2,7 @@
 
 export PYTHONPATH="..":$PYTHONPATH
 
-MODEL_IDs=("openai/whisper-tiny.en" "openai/whisper-small.en" "openai/whisper-base.en" "openai/whisper-medium.en" "openai/whisper-large" "openai/whisper-large-v2" "openai/whisper-large-v3" "distil-whisper/distil-medium.en" "distil-whisper/distil-large-v2" "distil-whisper/distil-large-v3" "nyrahealth/CrisperWhisper")
+MODEL_IDs=("openai/whisper-tiny.en" "openai/whisper-small.en" "openai/whisper-base.en" "openai/whisper-medium.en" "openai/whisper-large" "openai/whisper-large-v2" "openai/whisper-large-v3" "distil-whisper/distil-medium.en" "distil-whisper/distil-large-v2" "distil-whisper/distil-large-v3" "shunyalabs/pingala-v1-universal" "nyrahealth/CrisperWhisper")
 BATCH_SIZE=64
 
 num_models=${#MODEL_IDs[@]}


### PR DESCRIPTION
Hello Open-ASR team,

This PR adds my Whisper-based ASR model to the leaderboard. The modification is minimal yet it represents a model that has achieved record-breaking WER in evaluation. 

This model is the result of extensive fine-tuning, and deep research, which have directly contributed to its significant performance gains. The supporting paper is currently under review by scientific community and the model has already surpassed **2,000 downloads** on Hugging Face.

The model is continuing to gain traction, and it would be a miss for Hugging Face not to list it on the leaderboard at this point. Given the adherence to the PR submission guidelines and the demonstrated impact of the model, I urge the team to merge this PR swiftly to ensure the leaderboard reflects the latest advances and remains a credible source of truth for the ASR community.

The model has already been evaluated by the run_whisper.sh file under transformers model (file modified as part of PR) on a  **NVIDIA A100-SXM4-80GB** machine. Here is the summary of results:

********************************************************************************
Results per dataset:
********************************************************************************
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 4.24 %, RTFx = 126.71
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 6.00 %, RTFx = 252.69
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 4.98 %, RTFx = 282.11
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 0.99 %, RTFx = 325.63
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 1.73 %, RTFx = 294.24
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 1.10 %, RTFx = 396.44
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 1.41 %, RTFx = 357.42
shunyalabs/pingala-v1-universal | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 4.31 %, RTFx = 417.02

********************************************************************************
**Composite Results:**
********************************************************************************
 **shunyalabs/pingala-v1-universal: WER = 3.10 %**
 **shunyalabs/pingala-v1-universal: RTFx = 322.12**
********************************************************************************

We also have attached the output JSONL files to this PR.

[MODEL_shunyalabs-pingala-v1-universal_DATASET_hf-audio-esb-datasets-test-only-sorted_ami_test.zip](https://github.com/user-attachments/files/22058797/MODEL_shunyalabs-pingala-v1-universal_DATASET_hf-audio-esb-datasets-test-only-sorted_ami_test.zip)

Thank you for maintaining this important benchmark and for your prompt attention. We remain at your disposal for answering any questions to ensure a swift merge and subsequent listing on Open ASR leaderboard. 

PS: Please see first comment for other relevant PRs and info.