### PR TITLE
add support for aqua voice's avalon

### DIFF
--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -6,6 +6,7 @@ export OPENAI_API_KEY="your_api_key"
 export ASSEMBLYAI_API_KEY="your_api_key"
 export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
+export AQUAVOICE_API_KEY="your_api_key"
 
 MODEL_IDs=(
     "openai/gpt-4o-transcribe"
@@ -16,6 +17,7 @@ MODEL_IDs=(
     "revai/machine" # please use --use_url=True
     "revai/fusion" # please use --use_url=True
     "speechmatics/enhanced"
+    "aquavoice/avalon-v1-en"
 )
 
 num_models=${#MODEL_IDs[@]}


### PR DESCRIPTION
Model Card: [ASR for Human–AI Interaction](https://withaqua.com/research/avalon-model-card.pdf)
Blog: [Introducing Avalon](https://withaqua.com/blog/introducing-avalon)

[Get an API key here.](https://withaqua.com/api-dashboard)

Due to rate limits, we recommend running the script with `max_workers` set to 5 or fewer.