### PR TITLE
Restrict compound word normalization to multilingual scoring only

### DIFF
--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -102,7 +102,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""

--- a/nemo_asr/run_nemo_ml.sh
+++ b/nemo_asr/run_nemo_ml.sh
@@ -91,7 +91,7 @@ for MODEL_ID in "${MODEL_IDS[@]}"; do
     echo ""
     echo "📊 Scoring results for $MODEL_ID"
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
     echo "========================================================"
     echo ""

--- a/normalizer/eval_utils.py
+++ b/normalizer/eval_utils.py
@@ -132,13 +132,15 @@ def write_manifest(
     return manifest_path
 
 
-def score_results(directory: str, model_id: str = None):
+def score_results(directory: str, model_id: str = None, multilingual: bool = False):
     """
     Scores all result files in a directory and returns a composite score over all evaluated datasets.
 
     Args:
         directory: Path to the result directory, containing one or more jsonl files.
         model_id: Optional, model name to filter out result files based on model name.
+        multilingual: If True, apply compound word boundary normalization before
+                      WER computation. Should only be enabled for non-English benchmarks.
 
     Returns:
         Composite score over all evaluated datasets and a dictionary of all results.
@@ -190,10 +192,10 @@ def score_results(directory: str, model_id: str = None):
         duration = [datum["duration"] for datum in manifest]
         compute_rtfx = all(time) and all(duration)
 
-        # Normalize compound word boundaries before WER computation
-        wer_refs, wer_preds = normalize_compound_pairs(references, predictions)
+        if multilingual:
+            references, predictions = normalize_compound_pairs(references, predictions)
 
-        wer = wer_metric.compute(references=wer_refs, predictions=wer_preds)
+        wer = wer_metric.compute(references=references, predictions=predictions)
         wer = round(100 * wer, 2)
 
         if compute_rtfx:

--- a/omniasr/run_omniasr_ml.sh
+++ b/omniasr/run_omniasr_ml.sh
@@ -84,7 +84,7 @@ do
     # Evaluate results
     RUNDIR=`pwd` && \
     cd ../normalizer && \
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)" && \
     cd $RUNDIR
 
 done

--- a/phi/run_phi4_multimodal_ml.sh
+++ b/phi/run_phi4_multimodal_ml.sh
@@ -103,7 +103,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""

--- a/qwen/run_qwen3_asr_ml.sh
+++ b/qwen/run_qwen3_asr_ml.sh
@@ -100,7 +100,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""

--- a/transformers/run_whisper_ml.sh
+++ b/transformers/run_whisper_ml.sh
@@ -98,7 +98,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""

--- a/voxtral/run_voxtral_ml.sh
+++ b/voxtral/run_voxtral_ml.sh
@@ -104,7 +104,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""

--- a/voxtral/run_voxtral_realtime_ml.sh
+++ b/voxtral/run_voxtral_realtime_ml.sh
@@ -98,7 +98,7 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     # Evaluate results
     RUNDIR=`pwd`
     cd ../normalizer
-    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')"
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}', multilingual=True)"
     cd "$RUNDIR"
 
     echo ""


### PR DESCRIPTION
The normalize_compound_pairs() step introduced for multilingual WER evaluation was being applied unconditionally in score_results(), including for English benchmarks. This caused WER mismatches between run_eval.py (inference-time) and score_results() (post-scoring).

Add a multilingual flag (default False) to score_results() so compound normalization is only applied when explicitly opted in by _ml.sh scripts.