### PR TITLE
Improve --use_url error handling for long-form datasets

### DIFF
--- a/api/run_api_longform.sh
+++ b/api/run_api_longform.sh
@@ -26,9 +26,14 @@ MAX_WORKERS=10
 
 num_models=${#MODEL_IDs[@]}
 
+# Note: --use_url may fail for some long-form datasets if the datasets-server /rows
+# endpoint cannot serve very large exported Parquet row groups.
+# If that happens, rerun without --use_url.
+
 for (( i=0; i<${num_models}; i++ ));
 do
     MODEL_ID=${MODEL_IDs[$i]}
+
     python run_eval.py \
         --dataset_path="hf-audio/asr-leaderboard-longform" \
         --dataset="earnings21" \

--- a/api/run_eval.py
+++ b/api/run_eval.py
@@ -20,10 +20,18 @@ load_dotenv()
 def fetch_audio_urls(dataset_path, dataset, split, batch_size=100, max_retries=20):
     API_URL = "https://datasets-server.huggingface.co/rows"
 
+    headers = {}
+    if os.environ.get("HF_TOKEN") is not None:
+        headers["Authorization"] = f"Bearer {os.environ['HF_TOKEN']}"
+    else:
+        print("HF_TOKEN not set, might experience rate-limiting.")
+
     size_url = f"https://datasets-server.huggingface.co/size?dataset={dataset_path}&config={dataset}&split={split}"
-    size_response = requests.get(size_url).json()
-    total_rows = size_response["size"]["config"]["num_rows"]
-    audio_urls = []
+    size_response = requests.get(size_url, headers=headers)
+    size_response.raise_for_status()
+    size_data = size_response.json()
+    total_rows = size_data["size"]["config"]["num_rows"]
+
     for offset in tqdm(range(0, total_rows, batch_size), desc="Fetching audio URLs"):
         params = {
             "dataset": dataset_path,
@@ -36,24 +44,21 @@ def fetch_audio_urls(dataset_path, dataset, split, batch_size=100, max_retries=2
         retries = 0
         while retries <= max_retries:
             try:
-                headers = {}
-                if os.environ.get("HF_TOKEN") is not None:
-                    headers["Authorization"] = f"Bearer {os.environ['HF_TOKEN']}"
-                else:
-                    print("HF_TOKEN not set, might experience rate-limiting.")
-                response = requests.get(API_URL, params=params)
+                response = requests.get(API_URL, params=params, headers=headers)
                 response.raise_for_status()
                 data = response.json()
                 yield from data["rows"]
                 break
             except (requests.exceptions.RequestException, ValueError) as e:
                 retries += 1
-                print(
-                    f"Error fetching data: {e}, retrying ({retries}/{max_retries})..."
-                )
+                print(f"Error fetching data: {e}, retrying ({retries}/{max_retries})...")
                 time.sleep(10)
                 if retries >= max_retries:
-                    raise Exception("Max retries exceeded while fetching data.")
+                    raise RuntimeError(
+                        "Max retries exceeded while fetching dataset rows from the datasets-server /rows endpoint. "
+                        "This can happen for long-form datasets when exported Parquet row groups are too large for /rows. "
+                        "Try rerunning without --use_url."
+                    ) from e
 
 
 def transcribe_with_retry(
@@ -234,7 +239,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--use_url",
         action="store_true",
-        help="Use URL-based audio fetching instead of datasets",
+        help="Use dataset audio URLs instead of downloading audio locally. This may fail for some long-form datasets because the datasets-server /rows endpoint may not be able to serve very large exported Parquet row groups",
     )
 
     args = parser.parse_args()

--- a/api/run_eval_ml.py
+++ b/api/run_eval_ml.py
@@ -22,9 +22,18 @@ load_dotenv()
 def fetch_audio_urls(dataset_path, config_name, split, batch_size=100, max_retries=20):
     API_URL = "https://datasets-server.huggingface.co/rows"
 
+    headers = {}
+    if os.environ.get("HF_TOKEN") is not None:
+        headers["Authorization"] = f"Bearer {os.environ['HF_TOKEN']}"
+    else:
+        print("HF_TOKEN not set, might experience rate-limiting.")
+
     size_url = f"https://datasets-server.huggingface.co/size?dataset={dataset_path}&config={config_name}&split={split}"
-    size_response = requests.get(size_url).json()
-    total_rows = size_response["size"]["config"]["num_rows"]
+    size_response = requests.get(size_url, headers=headers)
+    size_response.raise_for_status()
+    size_data = size_response.json()
+    total_rows = size_data["size"]["config"]["num_rows"]
+
     for offset in tqdm(range(0, total_rows, batch_size), desc="Fetching audio URLs"):
         params = {
             "dataset": dataset_path,
@@ -37,24 +46,21 @@ def fetch_audio_urls(dataset_path, config_name, split, batch_size=100, max_retri
         retries = 0
         while retries <= max_retries:
             try:
-                headers = {}
-                if os.environ.get("HF_TOKEN") is not None:
-                    headers["Authorization"] = f"Bearer {os.environ['HF_TOKEN']}"
-                else:
-                    print("HF_TOKEN not set, might experience rate-limiting.")
-                response = requests.get(API_URL, params=params)
+                response = requests.get(API_URL, params=params, headers=headers)
                 response.raise_for_status()
                 data = response.json()
                 yield from data["rows"]
                 break
             except (requests.exceptions.RequestException, ValueError) as e:
                 retries += 1
-                print(
-                    f"Error fetching data: {e}, retrying ({retries}/{max_retries})..."
-                )
+                print(f"Error fetching data: {e}, retrying ({retries}/{max_retries})...")
                 time.sleep(10)
                 if retries >= max_retries:
-                    raise Exception("Max retries exceeded while fetching data.")
+                    raise RuntimeError(
+                        "Max retries exceeded while fetching dataset rows from the datasets-server /rows endpoint. "
+                        "This can happen for long-form datasets when exported Parquet row groups are too large for /rows. "
+                        "Try rerunning without --use_url."
+                    ) from e
 
 
 def transcribe_with_retry(
@@ -250,7 +256,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--use_url",
         action="store_true",
-        help="Use URL-based audio fetching instead of datasets",
+        help="Use dataset audio URLs instead of downloading audio locally. This may fail for some long-form datasets because the datasets-server /rows endpoint may not be able to serve very large exported Parquet row groups",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
This PR improves the `--use_url` path for long-form datasets by:
- passing auth headers correctly to datasets-server requests
- surfacing a clearer error when `/rows` repeatedly fails
- documenting that long-form datasets may need to be rerun without `--use_url`

## Motivation
The leaderboard repo consumes long-form datasets via the datasets-server `/rows` API when `--use_url` is enabled. For some long-form datasets, this can fail because exported Parquet row groups are too large for `/rows` to serve reliably. This PR makes that failure mode clearer and easier to recover from.

Closes #138