### PR TITLE
Update ABR models

### DIFF
--- a/abr/run_abr.sh
+++ b/abr/run_abr.sh
@@ -3,7 +3,7 @@ set -e
 
 export PYTHONPATH="..":$PYTHONPATH
 
-MODEL_IDs=("abr-ai/asr-19m-v2-en-32b")
+MODEL_IDs=("abr-ai/niagara-19m-batch.en" "abr-ai/niagara-38m-batch.en")
 BATCH_SIZE=256
 MAX_EVAL_SAMPLES=-1
 WARMUP_STEPS=5


### PR DESCRIPTION
## Description

This updates the previous 19M parameter `abr-ai/asr-19m-v2-en-32b` model (renamed to `abr-ai/niagara-19m-batch.en`), and adds a new 38M parameter model (`abr-ai/niagara-38m-batch.en`).

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

Please report your results (WER on each split, average WER, and RTFx) on the HF Hub by adding a `.eval_results/open_asr_leaderboard.yaml` file like [this](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026/blob/main/.eval_results/open_asr_leaderboard.yaml) in the model repo. Closed models can report their results in the PR text.

Results are available here:
- [abr-ai/niagara-19m-batch.en](https://huggingface.co/abr-ai/niagara-19m-batch.en/blob/main/.eval_results/open_asr_leaderboard.yaml)
- [abr-ai/niagara-38m-batch.en](https://huggingface.co/abr-ai/niagara-38m-batch.en/blob/main/.eval_results/open_asr_leaderboard.yaml)

Note that I have not included RTFx, as I don't have an A100 available to test on.

### My model is in Transformers 🤗
- [x] (If necessary) adapt [`transformers/run_eval.py`](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_eval.py) to use your checkpoint (using the `AutoModelForXXX` API).
- [x] Create a bash script like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_whisper.sh).
    - [x] Loops over all the [Open ASR Leaderboard](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard) subsets with all models.
    - [ ] Run on A100-SXM4-80GB GPU with maximum possible batch size and report on the HF Hub. (*If you don't have access to such a GPU, let us know so we can run it*).

Don't have access to an A100.