### PR TITLE
Add Reson8 API provider (resonant-1, resonant-1-flash)

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -52,3 +52,4 @@ from . import elevenlabs_provider
 from . import revai_provider
 from . import aquavoice_provider
 from . import zoom_provider
+from . import reson8_provider

--- a/api/providers/reson8_provider.py
+++ b/api/providers/reson8_provider.py
@@ -1,0 +1,85 @@
+import os
+import time
+import threading
+from typing import Optional
+
+import requests
+
+from . import APIProvider, register, PermanentError
+
+
+AUTH_URL = "https://api.reson8.dev/v1/auth/token"
+TRANSCRIBE_URL = "https://api.reson8.dev/v1/speech-to-text/prerecorded"
+TOKEN_REFRESH_MARGIN_S = 30
+MIN_AUDIO_DURATION_S = 0.16
+
+_token_lock = threading.Lock()
+_token_cache: dict = {"access_token": None, "expires_at": 0.0}
+
+
+def _get_access_token(api_key: str) -> str:
+    with _token_lock:
+        cached = _token_cache["access_token"]
+        if cached and _token_cache["expires_at"] - time.time() > TOKEN_REFRESH_MARGIN_S:
+            return cached
+
+        response = requests.post(
+            AUTH_URL,
+            headers={"Authorization": f"ApiKey {api_key}"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        _token_cache["access_token"] = data["access_token"]
+        _token_cache["expires_at"] = time.time() + float(data.get("expires_in", 600))
+        return _token_cache["access_token"]
+
+
+@register("reson8")
+class Reson8Provider(APIProvider):
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+    ) -> str:
+        api_key = os.getenv("RESON8_API_KEY")
+        if not api_key or api_key == "your_api_key":
+            raise PermanentError("RESON8_API_KEY is not set (or still the placeholder)")
+
+        if use_url:
+            audio_duration = sample["row"]["audio_length_s"]
+            if audio_duration < MIN_AUDIO_DURATION_S:
+                return "."
+            audio_url = sample["row"]["audio"][0]["src"]
+            resp = requests.get(audio_url, timeout=60)
+            resp.raise_for_status()
+            audio_bytes = resp.content
+        else:
+            audio_duration = (
+                len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
+            )
+            if audio_duration < MIN_AUDIO_DURATION_S:
+                return "."
+            with open(audio_file_path, "rb") as f:
+                audio_bytes = f.read()
+
+        params = {"encoding": "auto", "model": model_variant}
+        if language:
+            params["language"] = language
+
+        token = _get_access_token(api_key)
+        response = requests.post(
+            TRANSCRIBE_URL,
+            params=params,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/octet-stream",
+            },
+            data=audio_bytes,
+            timeout=300,
+        )
+        response.raise_for_status()
+        return response.json().get("text", "").strip()

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -8,6 +8,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export ZOOM_API_KEY="your_api_key"
+export RESON8_API_KEY="your_api_key"
 
 export HF_TOKEN="hf_your_key"
 
@@ -21,7 +22,9 @@ MODEL_IDs=(
     # "revai/fusion" # please use --use_url=True
     # "speechmatics/enhanced"
     # "aquavoice/avalon-v1-en"
-    "zoom/scribe_v1" # please use --use_url
+    "reson8/resonant-1"
+    "reson8/resonant-1-flash"
+    # "zoom/scribe_v1" # please use --use_url
 )
 
 MAX_WORKERS=32

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -22,8 +22,8 @@ MODEL_IDs=(
     # "revai/fusion" # please use --use_url=True
     # "speechmatics/enhanced"
     # "aquavoice/avalon-v1-en"
-    "reson8/resonant-1"
-    "reson8/resonant-1-flash"
+    "reson8/resonant-1" # please use --use_url
+    "reson8/resonant-1-flash" # please use --use_url
     # "zoom/scribe_v1" # please use --use_url
 )
 

--- a/api/run_api_longform.sh
+++ b/api/run_api_longform.sh
@@ -9,6 +9,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export SPEECHMATICS_API_KEY="your_api_key"
+export RESON8_API_KEY="your_api_key"
 
 MODEL_IDs=(
     "openai/gpt-4o-transcribe"
@@ -20,6 +21,8 @@ MODEL_IDs=(
     "revai/fusion" # please use --use_url=True
     "speechmatics/enhanced"
     "aquavoice/avalon-v1-en"
+    "reson8/resonant-1"
+    "reson8/resonant-1-flash"
 )
 
 MAX_WORKERS=10

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -11,6 +11,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export SPEECHMATICS_API_KEY="your_api_key"
+export RESON8_API_KEY="your_api_key"
 
 # Configuration
 MODEL_IDs=(
@@ -20,6 +21,8 @@ MODEL_IDs=(
     "assembly/universal-3-pro"
     "elevenlabs/scribe_v2"
     "speechmatics/enhanced"
+    "reson8/resonant-1"
+    "reson8/resonant-1-flash"
 )
 
 MAX_WORKERS=200


### PR DESCRIPTION
Adds [Reson8](https://reson8.dev) prerecorded ASR API as a new proprietary provider — `resonant-1` and `resonant-1-flash`. Auth uses a server-issued bearer token (10 min lifetime) cached at module level and refreshed when within 30 s of expiry.

To run:

```bash
export RESON8_API_KEY=...
export HF_TOKEN=...
cd api
bash run_api.sh           # English shortform
bash run_api_longform.sh  # English longform + CORAAL
bash run_api_ml.sh        # FLEURS / MCV / MLS (de, fr, it, es, pt)
```

### Results

```
********************************************************************************
Composite Results (English shortform):
********************************************************************************
reson8/resonant-1:        WER = 5.43 %
reson8/resonant-1-flash:  WER = 5.45 %
********************************************************************************
```

<details>
<summary>Per-dataset — shortform</summary>

```
reson8/resonant-1 | ami_test:           WER =  9.43 %
reson8/resonant-1 | earnings22_test:    WER =  8.99 %
reson8/resonant-1 | gigaspeech_test:    WER =  8.76 %
reson8/resonant-1 | librispeech_clean:  WER =  1.47 %
reson8/resonant-1 | librispeech_other:  WER =  2.85 %
reson8/resonant-1 | spgispeech_test:    WER =  3.06 %
reson8/resonant-1 | tedlium_test:       WER =  2.33 %
reson8/resonant-1 | voxpopuli_test:     WER =  6.56 %

reson8/resonant-1-flash | ami_test:           WER =  9.45 %
reson8/resonant-1-flash | earnings22_test:    WER =  9.06 %
reson8/resonant-1-flash | gigaspeech_test:    WER =  8.77 %
reson8/resonant-1-flash | librispeech_clean:  WER =  1.48 %
reson8/resonant-1-flash | librispeech_other:  WER =  2.88 %
reson8/resonant-1-flash | spgispeech_test:    WER =  3.06 %
reson8/resonant-1-flash | tedlium_test:       WER =  2.31 %
reson8/resonant-1-flash | voxpopuli_test:     WER =  6.58 %
```

</details>

<details>
<summary>Per-dataset — longform (incl. CORAAL)</summary>

```
reson8/resonant-1 | earnings21:  WER =  7.17 %
reson8/resonant-1 | earnings22:  WER = 11.35 %
reson8/resonant-1 | tedlium:     WER =  2.20 %
reson8/resonant-1 | coraal_PRV:  WER = 19.91 %
reson8/resonant-1 | coraal_ROC:  WER =  7.57 %
reson8/resonant-1 | coraal_VLD:  WER = 10.00 %
reson8/resonant-1: Avg = 8.30 % (without CORAAL: 6.91 %)

reson8/resonant-1-flash | earnings21:  WER =  7.10 %
reson8/resonant-1-flash | earnings22:  WER = 11.41 %
reson8/resonant-1-flash | tedlium:     WER =  2.12 %
reson8/resonant-1-flash | coraal_PRV:  WER = 19.55 %
reson8/resonant-1-flash | coraal_ROC:  WER =  7.56 %
reson8/resonant-1-flash | coraal_VLD:  WER =  9.97 %
reson8/resonant-1-flash: Avg = 8.25 % (without CORAAL: 6.88 %)
```

</details>

<details>
<summary>Per-dataset — multilingual</summary>

```
                  R-1     R-1-flash
fleurs_de         2.84    2.87
fleurs_fr         4.49    4.52
fleurs_it         1.79    1.82
fleurs_es         2.39    2.39
fleurs_pt         3.48    3.51
mcv_de            3.02    3.04
mcv_es            2.83    2.85
mcv_fr            5.57    5.59
mcv_it            2.67    2.72
mls_es            2.73    2.76
mls_fr            3.30    3.31
mls_it            6.14    6.14
mls_pt            4.45    4.46

Avg (13 cells)    3.52    3.54
```

</details>

RTFx not reported — runs are over the public internet, so wall-clock latency reflects network RTT and HF Hub audio I/O rather than model inference speed (same convention as `zoom/scribe_v1`, `elevenlabs/scribe_v*`, `aquavoice/avalon-v1-en`, `speechmatics/enhanced`).

These numbers match Reson8's published benchmarks at https://reson8.dev/blog/benchmarks within ±0.04 %-points on every overlapping dataset.

**Type of change:** New model (proprietary API)
