### PR TITLE
Granite Speech NAR

### DIFF
--- a/granite/run_eval_nar.py
+++ b/granite/run_eval_nar.py
@@ -1,0 +1,165 @@
+import argparse
+import os
+import torch
+import evaluate
+from normalizer import data_utils
+import time
+from tqdm import tqdm
+
+from transformers import AutoModel, AutoFeatureExtractor
+
+wer_metric = evaluate.load("wer")
+torch.set_float32_matmul_precision('high')
+
+
+def main(args):
+    # Load tokenizer
+    device = f"cuda:{args.device}" if args.device != -1 else "cpu"
+    model = AutoModel.from_pretrained(args.model_id, trust_remote_code=True, 
+                                      attn_implementation="flash_attention_2", 
+                                      device_map=device, dtype=torch.bfloat16).eval()
+    feature_extractor = AutoFeatureExtractor.from_pretrained(args.model_id, trust_remote_code=True)
+    feature_extractor.mel_filters = feature_extractor.mel_filters.to(device)
+    def benchmark(batch, min_new_tokens=None):
+        # Load audio inputs
+        audios = [torch.tensor(audio["array"], device=device).squeeze(0) for audio in batch["audio"]]
+        minibatch_size = len(audios)
+        # START TIMING
+        start_time = time.time()
+        inputs = feature_extractor(audios, device=device)
+        # Model Inference
+        with torch.inference_mode():
+            # Forward pass with raw_audio and attention_mask
+            output = model.generate(**inputs)
+            output_text = output.text_preds
+        # END TIMING
+        runtime = time.time() - start_time
+        # normalize by minibatch size since we want the per-sample time
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+        # normalize transcriptions with English normalizer
+        batch["predictions"] = [data_utils.normalizer(pred) for pred in output_text]
+        batch["references"] = batch["norm_text"]
+        return batch
+
+    if args.warmup_steps is not None:
+        dataset = data_utils.load_data(args)
+        dataset = data_utils.prepare_data(dataset)
+
+        num_warmup_samples = args.warmup_steps * args.batch_size
+        if args.streaming:
+            warmup_dataset = dataset.take(num_warmup_samples)
+        else:
+            warmup_dataset = dataset.select(range(min(num_warmup_samples, len(dataset))))
+        warmup_dataset = iter(warmup_dataset.map(benchmark, batch_size=args.batch_size, batched=True))
+
+        for _ in tqdm(warmup_dataset, desc="Warming up..."):
+            continue
+
+    dataset = data_utils.load_data(args)
+    if args.max_eval_samples is not None and args.max_eval_samples > 0:
+        print(f"Subsampling dataset to first {args.max_eval_samples} samples!")
+        if args.streaming:
+            dataset = dataset.take(args.max_eval_samples)
+        else:
+            dataset = dataset.select(range(min(args.max_eval_samples, len(dataset))))
+    dataset = data_utils.prepare_data(dataset)
+
+    dataset = dataset.map(
+        benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
+    )
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+    }
+    result_iter = iter(dataset)
+    for result in tqdm(result_iter, desc="Samples..."):
+        for key in all_results:
+            all_results[key].append(result[key])
+
+    # Write manifest results (WER and RTFX)
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset_path,
+        args.dataset,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
+    wer = wer_metric.compute(
+        references=all_results["references"], predictions=all_results["predictions"]
+    )
+    wer = round(100 * wer, 2)
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="ibm-granite/granite-speech-4.1-2b-nar",
+        help="HuggingFace model ID",
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="esb/datasets",
+        help="Dataset path. By default, it is `esb/datasets`",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Dataset name. *E.g.* `'librispeech_asr` for the LibriSpeech ASR dataset, or `'common_voice'` for Common Voice. The full list of dataset names "
+        "can be found at `https://huggingface.co/datasets/esb/datasets`",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Split of the dataset. *E.g.* `'validation`' for the dev split, or `'test'` for the test split.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=-1,
+        help="The device to run the pipeline on. -1 for CPU (default), 0 for the first GPU and so on.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="Number of samples to go through each streamed batch.",
+    )
+    parser.add_argument(
+        "--max_eval_samples",
+        type=int,
+        default=None,
+        help="Number of samples to be evaluated. Put a lower number e.g. 64 for testing this script.",
+    )
+    parser.add_argument(
+        "--no-streaming",
+        dest="streaming",
+        action="store_false",
+        help="Choose whether you'd like to download the entire dataset or stream it during the evaluation.",
+    )
+    parser.add_argument(
+        "--warmup_steps",
+        type=int,
+        default=2,
+        help="Number of warm-up steps to run before launching the timed runs.",
+    )
+    
+    args = parser.parse_args()
+    parser.set_defaults(streaming=False)
+
+    main(args)

--- a/granite/run_granite_nar.sh
+++ b/granite/run_granite_nar.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+export PYTHONPATH="..":$PYTHONPATH
+
+
+MODEL_ID="ibm-granite/granite-speech-4.1-2b-nar"
+BATCH_SIZE=256
+
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="voxpopuli" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="ami" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="earnings22" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="gigaspeech" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="librispeech" \
+    --split="test.clean" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="librispeech" \
+    --split="test.other" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="spgispeech" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+python run_eval_nar.py \
+    --model_id=${MODEL_ID} \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="tedlium" \
+    --split="test" \
+    --device=0 \
+    --batch_size=${BATCH_SIZE} \
+    --max_eval_samples=-1
+
+RUNDIR=`pwd` && \
+cd ../normalizer && \
+python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+cd $RUNDIR

--- a/granite/run_granite_nar.sh
+++ b/granite/run_granite_nar.sh
@@ -2,6 +2,8 @@
 
 export PYTHONPATH="..":$PYTHONPATH
 
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+export PYTORCH_ALLOC_CONF=expandable_segments:True
 
 MODEL_ID="ibm-granite/granite-speech-4.1-2b-nar"
 BATCH_SIZE=256

--- a/requirements/requirements_granite_nar.txt
+++ b/requirements/requirements_granite_nar.txt
@@ -1,0 +1,13 @@
+evaluate==0.4.6
+datasets==3.4.1
+peft==0.13.1
+torch==2.7.1
+torchaudio==2.7.1
+transformers==4.57.6
+accelerate==1.11.0
+safetensors==0.4.5
+huggingface-hub==0.36.0
+tokenizers==0.22.1
+flash-attn==2.8.3
+soundfile
+librosa


### PR DESCRIPTION
## Description
Add evaluation support for [**Granite Speech 4.1 2B NAR**](https://huggingface.co/ibm-granite/granite-speech-4.1-2b-nar), a non-autoregressive ASR model from IBM.


**New files:**
- `granite/run_eval_nar.py` — evaluation script with batched inference
- `granite/run_granite_nar.sh` — runs all 8 ESB benchmark subsets
- `requirements/requirements_granite_nar.txt` — dependencies (transformers, flash-attn, etc.)

**How to run:**
```bash
# an existing env with flash_attention_2 and transformers 4/5 should be fine
pip install -r requirements/requirements_granite_nar.txt 
cd granite
bash run_granite_nar.sh
```


## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist
The model is still private, we'll provide access tokens to the maintainers to review this PR. Results on A100-SXM4-80GB:
```
********************************************************************************
Results per dataset:
********************************************************************************
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_ami_test: WER = 8.03 %, RTFx = 704.06
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_earnings22_test: WER = 8.44 %, RTFx = 817.25
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_gigaspeech_test: WER = 10.16 %, RTFx = 899.86
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_librispeech_test.clea: WER = 1.28 %, RTFx = 831.55
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_librispeech_test.other: WER = 2.77 %, RTFx = 815.55
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_spgispeech_test: WER = 3.33 %, RTFx = 979.07
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_tedlium_test: WER = 3.62 %, RTFx = 730.68
ibm/granite-granite-speech-4.1-2b-nar | hf-audio-esb-datasets-test-only-sorted_voxpopuli_test: WER = 5.86 %, RTFx = 680.51

********************************************************************************
Composite Results:
********************************************************************************
ibm/granite-granite-speech-4.1-2b-nar: WER = 5.44 %
ibm/granite-granite-speech-4.1-2b-nar: RTFx = 910.59
********************************************************************************
```

- [x] Besides the main requirements [here](https://github.com/huggingface/open_asr_leaderboard/blob/main/requirements/requirements.txt), create a `requirements_MODEL.txt` file for the necessary dependencies as seen [here](https://github.com/huggingface/open_asr_leaderboard/tree/main/requirements).

In a new folder for your model: 
- [x] Create a `run_eval.py` script like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_eval.py). 
    - [x] Supports batch processing.
    - [x] Uses torch.compile and/or relevant optimization for inference (including warmup).
- [x] Create a bash script like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_whisper.sh).
    - [x] Loops over all the [Open ASR Leaderboard](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard) subsets.
    - [x] Tested on A100-SXM4-80GB GPU with maximum possible batch size.

## Related issues
N/A