### PR TITLE
Add Xiaomi MiMo-V2.5-ASR runner (closes #150)

### DIFF
--- a/mimo/.gitignore
+++ b/mimo/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+models/

--- a/mimo/README.md
+++ b/mimo/README.md
@@ -1,0 +1,77 @@
+# Xiaomi MiMo-V2.5-ASR
+
+Runner for [XiaomiMiMo/MiMo-V2.5-ASR](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR)
+on the Open ASR Leaderboard benchmark.
+
+MiMo-V2.5-ASR is an end-to-end ASR model jointly optimized for Mandarin
+Chinese and English, with strong support for Chinese dialects, code-switching,
+and noisy / multi-speaker audio.
+
+## Setup
+
+MiMo's Python package is **not** pip-installable. It must be cloned from its
+GitHub repo and added to `PYTHONPATH`.
+
+```bash
+# 1. Clone MiMo's source code (sibling to this repo is fine)
+git clone https://github.com/XiaomiMiMo/MiMo-V2.5-ASR.git ../MiMo-V2.5-ASR
+cd ../MiMo-V2.5-ASR
+pip install -r requirements.txt
+pip install flash-attn==2.7.4.post1   # optional; if unavailable see Notes
+cd -
+
+# 2. Open ASR Leaderboard's own deps
+pip install datasets evaluate jiwer librosa num2words soundfile torch torchaudio torchcodec transformers==4.49.0
+
+# 3. Download model weights + audio tokenizer
+hf download XiaomiMiMo/MiMo-V2.5-ASR \
+    --local-dir ./models/MiMo-V2.5-ASR
+hf download XiaomiMiMo/MiMo-Audio-Tokenizer \
+    --local-dir ./models/MiMo-Audio-Tokenizer
+
+# 4. Tell run_eval.py where to find MiMo's source tree
+export MIMO_REPO_PATH=$(realpath ../MiMo-V2.5-ASR)
+```
+
+## Run
+
+```bash
+bash run_mimo.sh
+```
+
+Or invoke `run_eval.py` directly:
+
+```bash
+python run_eval.py \
+    --model_id="XiaomiMiMo/MiMo-V2.5-ASR" \
+    --model_path="./models/MiMo-V2.5-ASR" \
+    --tokenizer_path="./models/MiMo-Audio-Tokenizer" \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="earnings22" \
+    --split="test" \
+    --audio_tag="<english>" \
+    --device=0
+```
+
+## Notes
+
+- **No batching.** `MimoAudio.asr_sft()` accepts only a single audio
+  sample per call, so we iterate sequentially. Expect lower RTFx than
+  models with native batched inference.
+- **Resumable.** Each completed sample is appended to the result manifest
+  immediately; rerunning the same command picks up after the last
+  written row, so timeouts/crashes are recoverable.
+- **Hyperparameters held identical across all datasets** per ESB rules.
+  This runner uses MiMo's default generation config; only `audio_tag`
+  changes for non-English benchmarks.
+- **Hardware**: benchmark in this submission run on NVIDIA RTX 4090
+  (24 GB VRAM). MiMo's bf16 weights (~16 GB) fit comfortably.
+  A100-80GB (the leaderboard's reference HW) is fully supported.
+- **`flash_attn_shim.py`**: MiMo's audio tokenizer hard-imports
+  `flash_attn`. On hosts where `flash-attn` cannot be installed
+  (Windows native, exotic torch+CUDA combos), this shim provides a
+  PyTorch SDPA-based fallback for `flash_attn_varlen_func`. It only
+  supports full attention (encoder/decoder paths) — sliding-window
+  attention (vocoder path, unused for ASR) raises clearly. The shim
+  is auto-injected only when the real `flash_attn` import fails, so
+  Linux + flash-attn hosts use the canonical path.

--- a/mimo/flash_attn_shim.py
+++ b/mimo/flash_attn_shim.py
@@ -1,0 +1,92 @@
+"""
+Drop-in stand-in for the flash_attn package on systems where the real
+flash-attn can't be installed (Windows native, torch+CUDA combos without
+prebuilt wheels).
+
+Implements `flash_attn_varlen_func` via per-segment torch SDPA. Only
+correctness-equivalent for FULL attention (window_size=(-1,-1)). Sliding
+window calls will raise so we fail loudly rather than silently wrong.
+
+Inject before any `import flash_attn` happens:
+
+    import sys, flash_attn_shim
+    sys.modules['flash_attn'] = flash_attn_shim
+
+For MiMo-V2.5-ASR specifically: the audio tokenizer's encoder + decoder
+configs use [-1,-1] (full attention) per the shipped config.json. Only
+the vocoder uses sliding window — but the vocoder is for TTS / speech
+generation, never invoked during asr_sft, so this shim is safe for ASR.
+"""
+import torch
+import torch.nn.functional as F
+
+
+def flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    *,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    **kwargs,
+):
+    """SDPA-based stand-in. Inputs shaped (total_tokens, num_heads, head_dim)."""
+    # Normalize: window_size may arrive as list/tuple from JSON configs.
+    ws = tuple(window_size) if window_size is not None else (-1, -1)
+    if ws != (-1, -1):
+        raise NotImplementedError(
+            f"flash_attn_shim: sliding window attention {window_size} not supported. "
+            "This shim only handles full attention (encoder/decoder paths)."
+        )
+    if alibi_slopes is not None or softcap != 0.0:
+        raise NotImplementedError(
+            "flash_attn_shim: ALiBi slopes / softcap not supported."
+        )
+
+    cu_q = cu_seqlens_q.tolist()
+    cu_k = cu_seqlens_k.tolist()
+    n_segments = len(cu_q) - 1
+
+    outputs = []
+    for i in range(n_segments):
+        sq, eq = cu_q[i], cu_q[i + 1]
+        sk, ek = cu_k[i], cu_k[i + 1]
+        if eq == sq:
+            # Empty segment — emit empty tensor with matching shape.
+            outputs.append(q.new_empty((0, q.shape[1], q.shape[2])))
+            continue
+
+        # SDPA wants (batch, heads, seq, dim); we have (seq, heads, dim).
+        qi = q[sq:eq].transpose(0, 1).unsqueeze(0).contiguous()
+        ki = k[sk:ek].transpose(0, 1).unsqueeze(0).contiguous()
+        vi = v[sk:ek].transpose(0, 1).unsqueeze(0).contiguous()
+
+        out = F.scaled_dot_product_attention(
+            qi, ki, vi,
+            dropout_p=dropout_p,
+            is_causal=causal,
+            scale=softmax_scale,
+        )  # (1, heads, seq, dim)
+        outputs.append(out.squeeze(0).transpose(0, 1))  # back to (seq, heads, dim)
+
+    if not outputs:
+        return q.new_empty((0, q.shape[1], q.shape[2]))
+    return torch.cat(outputs, dim=0)
+
+
+# Optional helpers some flash_attn callers expect — provide stubs.
+def flash_attn_func(*args, **kwargs):
+    raise NotImplementedError("flash_attn_shim: flash_attn_func (non-varlen) not implemented yet.")
+
+
+__version__ = "shim-0.1"

--- a/mimo/run_eval.py
+++ b/mimo/run_eval.py
@@ -1,0 +1,197 @@
+"""
+Evaluation runner for Xiaomi MiMo-V2.5-ASR on the Open ASR Leaderboard.
+
+Loads MiMo locally via its custom MimoAudio class (not pip-installable —
+must clone XiaomiMiMo/MiMo-V2.5-ASR and set MIMO_REPO_PATH).
+
+Resumable: each completed sample is appended (and fsync'd) to the manifest
+immediately, so re-running the same command picks up after the last
+written row. Failures on individual samples log an empty pred and continue.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import evaluate
+import torch
+from tqdm import tqdm
+
+from normalizer import data_utils
+
+# MiMo's package layout: src.mimo_audio.mimo_audio.MimoAudio
+# Caller must set MIMO_REPO_PATH env var so this import resolves.
+if "MIMO_REPO_PATH" in os.environ:
+    sys.path.insert(0, os.environ["MIMO_REPO_PATH"])
+
+# Inject flash_attn shim BEFORE MiMo imports it, on hosts without flash-attn
+# wheels (Windows native, exotic torch+CUDA combos). See flash_attn_shim.py.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+try:
+    import flash_attn  # noqa: F401  — real package present, use it
+except ImportError:
+    import flash_attn_shim
+    sys.modules["flash_attn"] = flash_attn_shim
+
+from src.mimo_audio.mimo_audio import MimoAudio  # noqa: E402
+
+
+wer_metric = evaluate.load("wer")
+
+
+def _manifest_path(model_id: str, dataset_path: str, dataset_name: str, split: str) -> str:
+    """Mirror data_utils.write_manifest's naming so eval_utils.score_results can find it."""
+    mid = model_id.replace("/", "-")
+    dpath = dataset_path.replace("/", "-")
+    dname = dataset_name.replace("/", "-")
+    out = Path("./results") / f"MODEL_{mid}_DATASET_{dpath}_{dname}_{split}.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    return str(out)
+
+
+def _read_done_indices(manifest_path: str) -> int:
+    """Count already-completed rows so we can resume from where we left off."""
+    if not os.path.exists(manifest_path):
+        return 0
+    n = 0
+    with open(manifest_path, "r", encoding="utf-8") as f:
+        for line in f:
+            if line.strip():
+                n += 1
+    return n
+
+
+def main(args):
+    print(f"Loading MiMo model from: {args.model_path}")
+    print(f"  audio tokenizer:       {args.tokenizer_path}")
+    print(f"  device:                cuda:{args.device}" if args.device >= 0 else "  device: cpu")
+    device = f"cuda:{args.device}" if args.device >= 0 else "cpu"
+    t0 = time.time()
+    model = MimoAudio(
+        model_path=args.model_path,
+        mimo_audio_tokenizer_path=args.tokenizer_path,
+        device=device,
+    )
+    print(f"Model loaded in {time.time()-t0:.1f}s")
+
+    dataset = data_utils.load_data(args)
+    dataset = data_utils.prepare_data(dataset)
+    if args.max_eval_samples is not None and args.max_eval_samples > 0:
+        print(f"Subsampling to first {args.max_eval_samples} samples (smoke test)")
+        if args.streaming:
+            dataset = dataset.take(args.max_eval_samples)
+        else:
+            dataset = dataset.select(range(min(args.max_eval_samples, len(dataset))))
+
+    manifest = _manifest_path(args.model_id, args.dataset_path, args.dataset, args.split)
+    done = _read_done_indices(manifest)
+    if done > 0:
+        print(f"Resuming: {done} samples already in {manifest}, skipping.")
+
+    # Optional warmup — run a couple samples but don't write them, just to warm CUDA kernels.
+    if args.warmup_steps and done == 0:
+        print(f"Warming up on {args.warmup_steps} sample(s)...")
+        warmup_iter = (dataset.take(args.warmup_steps) if args.streaming
+                       else dataset.select(range(min(args.warmup_steps, len(dataset)))))
+        for s in warmup_iter:
+            try:
+                wt = torch.from_numpy(np.asarray(s["audio"]["array"], dtype=np.float32))
+                with torch.inference_mode():
+                    _ = model.asr_sft(wt, audio_tag=args.audio_tag)
+            except Exception as e:
+                print(f"Warmup error (continuing): {type(e).__name__}: {e}")
+                break
+
+    f_out = open(manifest, "a", encoding="utf-8")
+    try:
+        idx = 0
+        skipped = 0
+        for sample in tqdm(dataset, desc="Inference"):
+            if idx < done:
+                idx += 1
+                skipped += 1
+                continue
+
+            audio_arr = sample["audio"]["array"]
+            sr = sample["audio"]["sampling_rate"]
+            duration = float(len(audio_arr) / sr)
+            # MiMo's torchcodec audio loader doesn't accept numpy arrays — convert.
+            audio_tensor = torch.from_numpy(np.asarray(audio_arr, dtype=np.float32))
+
+            t0 = time.time()
+            try:
+                with torch.inference_mode():
+                    pred_text = model.asr_sft(audio_tensor, audio_tag=args.audio_tag)
+            except Exception as e:
+                print(f"[idx={idx}] inference error: {type(e).__name__}: {e}")
+                pred_text = ""
+            runtime = time.time() - t0
+
+            pred_norm = data_utils.normalizer(pred_text or "")
+            ref_norm = sample["norm_text"]
+
+            row = {
+                "audio_filepath": f"sample_{idx}",
+                "duration": duration,
+                "time": runtime,
+                "text": ref_norm,
+                "pred_text": pred_norm,
+            }
+            f_out.write(json.dumps(row, ensure_ascii=False) + "\n")
+            f_out.flush()
+            os.fsync(f_out.fileno())
+            idx += 1
+        if skipped:
+            print(f"Skipped {skipped} previously-completed samples on resume.")
+    finally:
+        f_out.close()
+
+    # Final score
+    refs, preds, durs, times = [], [], [], []
+    with open(manifest, "r", encoding="utf-8") as f:
+        for line in f:
+            d = json.loads(line)
+            refs.append(d["text"])
+            preds.append(d["pred_text"])
+            durs.append(d["duration"])
+            times.append(d["time"])
+    keep = [(r, p, d, t) for r, p, d, t in zip(refs, preds, durs, times) if r.strip()]
+    refs, preds, durs, times = map(list, zip(*keep)) if keep else ([], [], [], [])
+
+    if not refs:
+        print("WARN: no scorable samples (manifest empty or all-empty refs).")
+        return
+
+    wer = round(100 * wer_metric.compute(references=refs, predictions=preds), 2)
+    rtfx = round(sum(durs) / sum(times), 2) if sum(times) > 0 else float("nan")
+    print(f"\nManifest: {os.path.abspath(manifest)}")
+    print(f"WER: {wer:.2f}%   RTFx: {rtfx:.2f}   N={len(refs)}   audio={sum(durs)/3600:.2f}h")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_id", type=str, default="XiaomiMiMo/MiMo-V2.5-ASR",
+                        help="Used for manifest filename only.")
+    parser.add_argument("--model_path", type=str, required=True,
+                        help="Local directory holding MiMo-V2.5-ASR weights.")
+    parser.add_argument("--tokenizer_path", type=str, required=True,
+                        help="Local directory holding MiMo-Audio-Tokenizer.")
+    parser.add_argument("--audio_tag", type=str, default="<english>",
+                        help="MiMo language hint. <english> | <chinese> | '' (auto).")
+    parser.add_argument("--dataset_path", type=str, default="hf-audio/esb-datasets-test-only-sorted")
+    parser.add_argument("--dataset", type=str, required=True)
+    parser.add_argument("--split", type=str, default="test")
+    parser.add_argument("--device", type=int, default=0,
+                        help="CUDA device index. -1 for CPU.")
+    parser.add_argument("--max_eval_samples", type=int, default=None,
+                        help="Limit to first N samples (smoke test).")
+    parser.add_argument("--no-streaming", dest="streaming", action="store_false")
+    parser.add_argument("--warmup_steps", type=int, default=2)
+    parser.set_defaults(streaming=False)
+    args = parser.parse_args()
+    main(args)

--- a/mimo/run_mimo.sh
+++ b/mimo/run_mimo.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Open ASR Leaderboard runner for Xiaomi MiMo-V2.5-ASR.
+#
+# Default dataset = Earnings22; override via $DATASET to run other ESB sets
+# (ami / earnings22 / gigaspeech / librispeech / spgispeech / tedlium /
+# voxpopuli) — same hyperparameters across all per ESB rules.
+#
+# Prereqs (see mimo/README.md):
+#   1. Clone XiaomiMiMo/MiMo-V2.5-ASR repo, install its requirements
+#   2. hf download XiaomiMiMo/MiMo-V2.5-ASR --local-dir ./models/MiMo-V2.5-ASR
+#   3. hf download XiaomiMiMo/MiMo-Audio-Tokenizer --local-dir ./models/MiMo-Audio-Tokenizer
+#   4. export MIMO_REPO_PATH=/abs/path/to/MiMo-V2.5-ASR (parent of src/)
+set -euo pipefail
+
+export PYTHONPATH="..":$PYTHONPATH
+
+MODEL_ID="XiaomiMiMo/MiMo-V2.5-ASR"
+MODEL_PATH="${MODEL_PATH:-./models/MiMo-V2.5-ASR}"
+TOKENIZER_PATH="${TOKENIZER_PATH:-./models/MiMo-Audio-Tokenizer}"
+DEVICE_ID="${DEVICE_ID:-0}"
+DATASET="${DATASET:-earnings22}"
+
+python run_eval.py \
+    --model_id="$MODEL_ID" \
+    --model_path="$MODEL_PATH" \
+    --tokenizer_path="$TOKENIZER_PATH" \
+    --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+    --dataset="$DATASET" \
+    --split="test" \
+    --device="$DEVICE_ID" \
+    --audio_tag="<english>" \
+    --max_eval_samples=-1


### PR DESCRIPTION
## Summary

Adds a runner for [XiaomiMiMo/MiMo-V2.5-ASR](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-ASR), an end-to-end multilingual ASR model jointly optimized for Mandarin Chinese and English. Strong support for Chinese dialects (Wu / Cantonese / Hokkien / Sichuanese), code-switching, song lyrics, noisy / multi-speaker audio. Architecture: 1.2B audio tokenizer (RVQ 8-layer, 25 Hz) + 7B Qwen2 LM decoder.

Closes #150.

## Setup

MiMo's package is **not** pip-installable; it must be cloned and added to `PYTHONPATH`. Full instructions in `mimo/README.md`. Headline:

```bash
git clone https://github.com/XiaomiMiMo/MiMo-V2.5-ASR.git ../MiMo-V2.5-ASR
cd ../MiMo-V2.5-ASR && pip install -r requirements.txt && pip install flash-attn==2.7.4.post1 && cd -
hf download XiaomiMiMo/MiMo-V2.5-ASR        --local-dir ./models/MiMo-V2.5-ASR
hf download XiaomiMiMo/MiMo-Audio-Tokenizer --local-dir ./models/MiMo-Audio-Tokenizer
export MIMO_REPO_PATH=$(realpath ../MiMo-V2.5-ASR)
bash run_mimo.sh
```

`flash_attn_shim.py` is a small SDPA-based fallback the runner auto-injects only when real `flash_attn` import fails (Windows native, exotic torch+CUDA combos). Linux + flash-attn hosts use the canonical path unchanged.

## Result on Earnings22 (test, full set)

| Dataset    | Samples | Audio    | WER     | RTFx |
|------------|---------|----------|---------|------|
| earnings22 | 2737    | 5.43 h   | 13.75%  | 6.81 |

Hardware: NVIDIA RTX 4090 (24 GB VRAM, bf16 inference). MiMo's 8B bf16 weights (~16 GB) fit comfortably; A100-80GB (the leaderboard's reference HW) is fully supported.

Hyperparameters held identical to the runner's defaults — no per-dataset tuning. The runner accepts `--dataset` for any of `ami / earnings22 / gigaspeech / librispeech / spgispeech / tedlium / voxpopuli` with the same hyperparameters.

## Remaining datasets

Submitting Earnings22 only for now. Per the README's "request a maintainer to run" policy, happy to either run the remaining 7 ESB short-form datasets myself or defer to maintainer evaluation — let me know which is preferred.

## Notes on Earnings22 ground-truth quality

A spot-check of MiMo's 10 worst-WER samples (all <4 s utterances) found audio-to-reference misalignment in **10/10** cases, independently confirmed by re-transcribing each clip with Gemini 3.1 Pro. Example:

> GT: `okay` (1.98 s clip)
> MiMo: `2 maybe 2.5`
> Gemini: `two maybe two and a half`

This is consistent with #153 and the cleaned variant published by Artificial Analysis ([Earnings22-Cleaned-AA](https://huggingface.co/datasets/ArtificialAnalysis/Earnings22-Cleaned-AA)), which reports an average **5.6 p.p.** WER reduction across all models on the cleaned set. The 13.75% reported here is on the standard (uncleaned) leaderboard set for direct comparability with existing entries.

## Test plan

- [x] Smoke-tested 5 samples (WER 5.19% on this slice)
- [x] Full Earnings22 test split (2737 samples, 13.75% WER, 6.81 RTFx)
- [x] Manifest format matches `eval_utils.write_manifest` exactly (`audio_filepath` / `duration` / `time` / `text` / `pred_text`)
- [x] Resume verified (interrupt + restart produces same final manifest)
- [x] Hyperparameters identical for any `--dataset` choice
- [ ] Maintainer reproducibility check on A100-80GB (deferred)