### PR TITLE
Add HOJO ASR V1 model

### DIFF
--- a/hojo/run_eval.py
+++ b/hojo/run_eval.py
@@ -1,6 +1,3 @@
-import sys
-sys.path.append("/speech/users/zhangweiyu/train_env/git_code/asr_llm_train/dist_env/hojo_asr")
-
 import argparse
 import os
 import torch

--- a/hojo/run_eval.py
+++ b/hojo/run_eval.py
@@ -58,6 +58,19 @@ def main(args):
         for key in all_results:
             all_results[key].append(result[key])
 
+    # Write manifest results (WER and RTFX)
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset_path,
+        args.dataset,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
     wer = wer_metric.compute(
         references=all_results["references"], predictions=all_results["predictions"]
     )

--- a/hojo/run_eval.py
+++ b/hojo/run_eval.py
@@ -1,0 +1,122 @@
+import sys
+sys.path.append("/speech/users/zhangweiyu/train_env/git_code/asr_llm_train/dist_env/hojo_asr")
+
+import argparse
+import os
+import torch
+from datasets import load_dataset
+from hojo_asr import HOJO_ASR
+import evaluate
+from normalizer import data_utils
+import time
+from tqdm import tqdm
+
+wer_metric = evaluate.load("wer")
+
+
+def main(args):
+    # Load hojo model
+    model = HOJO_ASR.load_model(args.model_id, device=args.device)
+
+    dataset = data_utils.load_data(args)
+    dataset = data_utils.prepare_data(dataset)
+
+    def benchmark(batch):
+        # Load audio inputs
+        audios = [audio["array"] for audio in batch["audio"]] 
+        batch["audio_length_s"] = [len(audio) / batch["audio"][0]["sampling_rate"] for audio in audios]
+        minibatch_size = len(audios)
+
+        # START TIMING
+        start_time = time.time()
+
+        results = model.run_infer(audios, batch_size=args.batch_size)
+
+        # Extract text predictions
+        pred_text = [val["text"] for val in results]
+
+        # END TIMING
+        runtime = time.time() - start_time
+
+        # normalize by minibatch size since we want the per-sample time
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+
+        # normalize transcriptions with English normalizer
+        batch["predictions"] = [data_utils.normalizer(pred) for pred in pred_text]
+        batch["references"] = batch["norm_text"]
+        return batch
+
+    dataset = dataset.map(
+        benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
+    )
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+    }
+    result_iter = iter(dataset)
+    for result in tqdm(result_iter, desc="Samples..."):
+        for key in all_results:
+            all_results[key].append(result[key])
+
+    wer = wer_metric.compute(
+        references=all_results["references"], predictions=all_results["predictions"]
+    )
+    wer = round(100 * wer, 2)
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        default="/speech/speech_data/pretrained_models/Qwen3-ASR-1.7B",
+        help="Model identifier. Should be loadable with qwen_asr",
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="esb/datasets",
+        help="Dataset path. By default, it is `esb/datasets`",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Dataset name. *E.g.* `'librispeech_asr` for the LibriSpeech ASR dataset, or `'common_voice'` for Common Voice. The full list of dataset names "
+        "can be found at `https://huggingface.co/datasets/esb/datasets`",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Split of the dataset. *E.g.* `'validation`' for the dev split, or `'test'` for the test split.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=-1,
+        help="The device to run the pipeline on. -1 for CPU (default), 0 for the first GPU and so on.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="Number of samples to go through each streamed batch.",
+    )
+    parser.add_argument(
+        "--no-streaming",
+        dest="streaming",
+        action="store_false",
+        help="Choose whether you'd like to download the entire dataset or stream it during the evaluation.",
+    )
+
+    args = parser.parse_args()
+    parser.set_defaults(streaming=False)
+
+    main(args)

--- a/hojo/run_hojo.sh
+++ b/hojo/run_hojo.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+export PYTHONPATH="..":$PYTHONPATH
+
+MODEL_IDs=(
+    "HojoAI/Hojo-ASR-V1"
+)
+
+BATCH_SIZE=64
+
+num_models=${#MODEL_IDs[@]}
+
+for (( i=0; i<${num_models}; i++ ));
+do
+    MODEL_ID=${MODEL_IDs[$i]}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="voxpopuli" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="ami" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="earnings22" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="gigaspeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.clean" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="librispeech" \
+        --split="test.other" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="spgispeech" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="hf-audio/esb-datasets-test-only-sorted" \
+        --dataset="tedlium" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE}
+
+    # Evaluate results
+    RUNDIR=`pwd` && \
+    cd ../normalizer && \
+    python -c "import eval_utils; eval_utils.score_results('${RUNDIR}/results', '${MODEL_ID}')" && \
+    cd $RUNDIR
+
+done

--- a/requirements/requirements_hojo.txt
+++ b/requirements/requirements_hojo.txt
@@ -1,0 +1,1 @@
+hojo-asr


### PR DESCRIPTION
## Description
Add Hojo-ASR model , a high-performance conversational speech recognition model powered by the Qwen3 LLM decoder. It adopts the classic Encoder-Adapter-LLM framework, fully leveraging acoustic fine-grained features and strong LLM semantic capabilities.

Optimized with multi-stage modular training and reinforcement learning, the model specializes in complex real-world scenarios including noisy environments, informal pronunciation, oral correction and Chinese-English code-switching. It currently supports accurate recognition of Mandarin, English, Cantonese, and Sichuan dialect, delivering balanced accuracy and inference efficiency for industrial deployment.

Hosted on the Hub at [HojoAI/Hojo-ASR](https://github.com/HojoAI/Hojo-ASR/tree/main)

```bash
cd hojo
sh run_hojo.sh
```

| Dataset | Hojo-ASR V1 |
|:--------:|:-----------------:|
| AMI | 8.64 |
| Earnings22 | 8.54 |
| Gigaspeech | 7.6 |
| LibriSpeech Clean | 1.74 |
| LibriSpeech Other | 3.66 |
| SPGISpeech | 1.92 |
| Tedlium | 3.13 |
| Voxpopuli | 7.02 |

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

### My model is not in Transformers (yet 🙃)
- [x] Besides the main requirements [here](https://github.com/huggingface/open_asr_leaderboard/blob/main/requirements/requirements.txt), create a `requirements_MODEL.txt` file for the necessary dependencies as seen [here](https://github.com/huggingface/open_asr_leaderboard/tree/main/requirements).

In a new folder for your model: 
- [x] Create a `run_eval.py` script like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_eval.py). 
    - [x] Supports batch processing.
    - [ ] Uses torch.compile and/or relevant optimization for inference (including warmup).
- [x] Create a bash script like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_whisper.sh).
    - [x] Loops over all the [Open ASR Leaderboard](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard) subsets.
    - [x] Tested on A100-SXM4-80GB GPU with maximum possible batch size (*if you don't have access to such a GPU, let us know so we can run it*).


## New Dataset Checklist
- [ ] The dataset is hosted on the HF Hub.
- [ ] Create a new Bash script with one of the model suites. For example, adapting the [Whisper](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_whisper.sh) or [Voxtral](https://github.com/huggingface/open_asr_leaderboard/blob/main/voxtral/run_voxtral.sh) script to run the eval on that new dataset (adding a call like [this](https://github.com/huggingface/open_asr_leaderboard/blob/main/transformers/run_whisper.sh#L14-L21)).

## Related issues
Closes #