### PR TITLE
Microsoft Azure Speech API for EN, ML benchmark

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -52,3 +52,4 @@ from . import elevenlabs_provider
 from . import revai_provider
 from . import aquavoice_provider
 from . import zoom_provider
+from . import azure_provider

--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -52,4 +52,4 @@ from . import elevenlabs_provider
 from . import revai_provider
 from . import aquavoice_provider
 from . import zoom_provider
-from . import azure_provider
+from . import microsoft_azure_provider

--- a/api/providers/azure_provider.py
+++ b/api/providers/azure_provider.py
@@ -1,0 +1,62 @@
+import requests
+import os
+import io
+import json
+from typing import Optional
+
+from . import APIProvider, register
+
+MIME_MAP = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".flac": "audio/flac"}
+
+
+@register("azure")
+class AzureProvider(APIProvider):
+    ENDPOINT = "https://eastus.api.cognitive.microsoft.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15"
+
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+        prompt: Optional[str] = None, 
+    ) -> str:
+        api_key = os.getenv("AZURE_API_KEY")
+        if not api_key or api_key == "your_api_key":
+            raise ValueError("AZURE_API_KEY environment variable not set")
+
+        definition = {
+            "enhancedMode": {
+                "enabled": True,
+                "task": "transcribe"
+            }
+        }
+        if prompt is not None:
+            # E.g., prompt = "Output must be in lexical format."
+            definition["enhancedMode"]["prompt"] = [prompt]
+
+        if use_url:
+            file_url = sample["row"]["audio"][0]["src"]
+            audio_resp = requests.get(file_url, timeout=120)
+            audio_resp.raise_for_status()
+            audio_data = io.BytesIO(audio_resp.content)
+            files = {
+                "audio": ("audio.wav", audio_data, "audio/wav"),
+                "definition": (None, json.dumps(definition), "application/json"),
+            }
+        else:
+            mime = MIME_MAP.get(os.path.splitext(audio_file_path)[1].lower(), "audio/wav")
+            files = {
+                "audio": (audio_file_path, open(audio_file_path, "rb"), mime),
+                "definition": (None, json.dumps(definition), "application/json"),
+            }
+
+        resp = requests.post(
+            self.ENDPOINT,
+            headers={"Ocp-Apim-Subscription-Key": api_key},
+            files=files,
+            timeout=300,
+        )
+        resp.raise_for_status()
+        return resp.json().get("combinedPhrases", [{}])[0].get("text", "") or "."

--- a/api/providers/azure_provider.py
+++ b/api/providers/azure_provider.py
@@ -11,7 +11,7 @@ MIME_MAP = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".fl
 
 @register("azure")
 class AzureProvider(APIProvider):
-    ENDPOINT = "https://eastus.api.cognitive.microsoft.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15"
+    ENDPOINT = "https://northeurope.api.cognitive.microsoft.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15"
 
     def transcribe(
         self,
@@ -29,7 +29,8 @@ class AzureProvider(APIProvider):
         definition = {
             "enhancedMode": {
                 "enabled": True,
-                "task": "transcribe"
+                "task": "transcribe",
+                "targetLanguage": language,
             }
         }
         if prompt is not None:
@@ -51,7 +52,6 @@ class AzureProvider(APIProvider):
                 "audio": (audio_file_path, open(audio_file_path, "rb"), mime),
                 "definition": (None, json.dumps(definition), "application/json"),
             }
-
         resp = requests.post(
             self.ENDPOINT,
             headers={"Ocp-Apim-Subscription-Key": api_key},

--- a/api/providers/microsoft_azure_provider.py
+++ b/api/providers/microsoft_azure_provider.py
@@ -9,9 +9,20 @@ from . import APIProvider, register
 MIME_MAP = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".flac": "audio/flac"}
 
 
-@register("azure")
-class AzureProvider(APIProvider):
+@register("microsoft")
+class MicrosoftAzureProvider(APIProvider):
     ENDPOINT = "https://northeurope.api.cognitive.microsoft.com/speechtotext/transcriptions:transcribe?api-version=2025-10-15"
+
+    # support 26 languages, list of locales in ML benchmark
+    # It is Multi-lingual model, can use without specifying the language.
+    LOCALE_DICT = {
+        "en": "en-US",
+        "es": "es-ES",
+        "fr": "fr-FR",
+        "de": "de-DE",
+        "it": "it-IT",
+        "pt": "pt-PT",
+    }
 
     def transcribe(
         self,
@@ -26,12 +37,14 @@ class AzureProvider(APIProvider):
         if not api_key or api_key == "your_api_key":
             raise ValueError("AZURE_API_KEY environment variable not set")
 
+        locale = self.LOCALE_DICT.get(language, "")
         definition = {
+            "locales": [locale],
+            "profanityFilterMode": "None",
             "enhancedMode": {
                 "enabled": True,
                 "task": "transcribe",
-                "targetLanguage": language,
-            }
+            },
         }
         if prompt is not None:
             # E.g., prompt = "Output must be in lexical format."
@@ -42,21 +55,23 @@ class AzureProvider(APIProvider):
             audio_resp = requests.get(file_url, timeout=120)
             audio_resp.raise_for_status()
             audio_data = io.BytesIO(audio_resp.content)
-            files = {
-                "audio": ("audio.wav", audio_data, "audio/wav"),
-                "definition": (None, json.dumps(definition), "application/json"),
-            }
+            files = [
+                ("definition", (None, json.dumps(definition))),
+                ("audio", ("audio.wav", audio_data, "audio/wav")),
+            ]
         else:
             mime = MIME_MAP.get(os.path.splitext(audio_file_path)[1].lower(), "audio/wav")
-            files = {
-                "audio": (audio_file_path, open(audio_file_path, "rb"), mime),
-                "definition": (None, json.dumps(definition), "application/json"),
-            }
+            files = [
+                ("definition", (None, json.dumps(definition))),
+                ("audio", (audio_file_path, open(audio_file_path, "rb"), mime)),
+            ]
         resp = requests.post(
             self.ENDPOINT,
             headers={"Ocp-Apim-Subscription-Key": api_key},
             files=files,
             timeout=300,
         )
+        if not resp.ok:
+            print(f"Azure API error {resp.status_code}: {resp.text}")
         resp.raise_for_status()
         return resp.json().get("combinedPhrases", [{}])[0].get("text", "") or "."

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -22,12 +22,12 @@ MODEL_IDs=(
     # "revai/fusion" # please use --use_url=True
     # "speechmatics/enhanced"
     # "aquavoice/avalon-v1-en"
-    "zoom/scribe_v1" # please use --use_url
-    "azure/fastllm"
+    # "zoom/scribe_v1" # please use --use_url
+    "microsoft/azure-speech-05-2026"
 )
 
-MAX_WORKERS=32
-DATASET_PATH="hf-audio/esb-datasets-test-only-sorted"
+MAX_WORKERS=20
+DATASET_PATH="hf-audio/open-asr-leaderboard"
 
 declare -a EVAL_DATASETS=(
     "ami:test"
@@ -40,6 +40,9 @@ declare -a EVAL_DATASETS=(
     "voxpopuli:test"
 )
 
+# Datasets that require lexical format prompt
+LEXICAL_DATASETS="librispeech gigaspeech tedlium"
+
 num_models=${#MODEL_IDs[@]}
 
 for (( i=0; i<${num_models}; i++ ));
@@ -50,13 +53,18 @@ do
         DATASET="${entry%%:*}"
         SPLIT="${entry##*:}"
 
+        PROMPT_ARGS=()
+        if [[ "$MODEL_ID" == microsoft/* ]] && [[ " $LEXICAL_DATASETS " == *" $DATASET "* ]]; then
+            PROMPT_ARGS=(--prompt "Output must be in lexical format.")
+        fi
+
         python run_eval.py \
             --dataset_path="$DATASET_PATH" \
             --dataset="$DATASET" \
             --split="$SPLIT" \
             --model_name ${MODEL_ID} \
             --max_workers ${MAX_WORKERS} \
-            --use_url
+            "${PROMPT_ARGS[@]}"
     done
 
     # Evaluate results

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -8,6 +8,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export ZOOM_API_KEY="your_api_key"
+export AZURE_API_KEY="your_api_key"
 
 export HF_TOKEN="hf_your_key"
 
@@ -22,6 +23,7 @@ MODEL_IDs=(
     # "speechmatics/enhanced"
     # "aquavoice/avalon-v1-en"
     "zoom/scribe_v1" # please use --use_url
+    "azure/fastllm"
 )
 
 MAX_WORKERS=32

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -11,6 +11,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export SPEECHMATICS_API_KEY="your_api_key"
+export AZURE_API_KEY="your_api_key"
 
 # Configuration
 MODEL_IDs=(
@@ -20,6 +21,7 @@ MODEL_IDs=(
     "assembly/universal-3-pro"
     "elevenlabs/scribe_v2"
     "speechmatics/enhanced"
+    "azure/fastllm"
 )
 
 MAX_WORKERS=200

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -15,23 +15,26 @@ export AZURE_API_KEY="your_api_key"
 
 # Configuration
 MODEL_IDs=(
-    "openai/gpt-4o-transcribe"
-    "openai/gpt-4o-mini-transcribe"
-    "openai/whisper-1"
-    "assembly/universal-3-pro"
-    "elevenlabs/scribe_v2"
-    "speechmatics/enhanced"
-    "azure/fastllm"
+    # "openai/gpt-4o-transcribe"
+    # "openai/gpt-4o-mini-transcribe"
+    # "openai/whisper-1"
+    # "assembly/universal-3-pro"
+    # "elevenlabs/scribe_v2"
+    # "speechmatics/enhanced"
+    "microsoft/azure-speech-05-2026"
 )
 
-MAX_WORKERS=200
+MAX_WORKERS=20
 DATASET_PATH="nithinraok/asr-leaderboard-datasets"
 
 # German, French, Italian, Spanish, Portuguese
-DATASET_NAMES=("fleurs" "mcv" "mls")
+DATASET_NAMES=("fleurs" "mls" "mcv")
 DATASET_LANGS_fleurs="de fr it es pt"
 DATASET_LANGS_mcv="de es fr it"
 DATASET_LANGS_mls="es fr it pt"
+
+# Datasets that require lexical format prompt (azure only)
+LEXICAL_DATASETS="mls-it"
 
 # Function to run evaluation
 run_evaluation() {
@@ -39,6 +42,12 @@ run_evaluation() {
     local dataset=$2
     local language=$3
     local config_name="${dataset}_${language}"
+
+    # Build prompt args for azure + lexical datasets
+    local prompt_args=()
+    if [[ "$model_id" == microsoft/* ]] && [[ " $LEXICAL_DATASETS " == *" ${dataset}-${language} "* ]]; then
+        prompt_args=(--prompt "Output must be in lexical format.")
+    fi
 
     echo ""
     echo "Running evaluation: $config_name"
@@ -54,7 +63,8 @@ run_evaluation() {
         --language="$language" \
         --split="test" \
         --model_name="$model_id" \
-        --max_workers="$MAX_WORKERS"
+        --max_workers="$MAX_WORKERS" \
+        "${prompt_args[@]}"
 
     local exit_code=$?
 

--- a/api/run_eval.py
+++ b/api/run_eval.py
@@ -63,12 +63,16 @@ def transcribe_with_retry(
     max_retries=10,
     use_url=False,
     language="en",
+    prompt=None,
 ):
     provider, variant = get_provider(model_name)
+    kwargs = dict(use_url=use_url, language=language)
+    if prompt is not None:
+        kwargs["prompt"] = prompt
     retries = 0
     while retries <= max_retries:
         try:
-            return provider.transcribe(variant, audio_file_path, sample, use_url=use_url, language=language)
+            return provider.transcribe(variant, audio_file_path, sample, **kwargs)
         except PermanentError:
             raise
         except Exception as e:
@@ -98,6 +102,7 @@ def transcribe_dataset(
     use_url=False,
     max_samples=None,
     max_workers=4,
+    prompt=None,
 ):
     if use_url:
         audio_rows = fetch_audio_urls(dataset_path, dataset, split)
@@ -126,7 +131,7 @@ def transcribe_dataset(
             start = time.time()
             try:
                 transcription = transcribe_with_retry(
-                    model_name, None, sample, use_url=True
+                    model_name, None, sample, use_url=True, prompt=prompt
                 )
             except Exception as e:
                 print(f"Failed to transcribe after retries: {e}")
@@ -149,7 +154,7 @@ def transcribe_dataset(
             start = time.time()
             try:
                 transcription = transcribe_with_retry(
-                    model_name, tmp_path, sample, use_url=False
+                    model_name, tmp_path, sample, use_url=False, prompt=prompt
                 )
             except Exception as e:
                 print(f"Failed to transcribe after retries: {e}")
@@ -236,6 +241,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Use URL-based audio fetching instead of datasets",
     )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="Optional prompt to pass to the provider (e.g., 'Output must be in lexical format.')",
+    )
 
     args = parser.parse_args()
 
@@ -247,4 +258,5 @@ if __name__ == "__main__":
         use_url=args.use_url,
         max_samples=args.max_samples,
         max_workers=args.max_workers,
+        prompt=args.prompt,
     )

--- a/api/run_eval_ml.py
+++ b/api/run_eval_ml.py
@@ -64,12 +64,16 @@ def transcribe_with_retry(
     max_retries=10,
     use_url=False,
     language="en",
+    prompt=None,
 ):
     provider, variant = get_provider(model_name)
+    kwargs = dict(use_url=use_url, language=language)
+    if prompt is not None:
+        kwargs["prompt"] = prompt
     retries = 0
     while retries <= max_retries:
         try:
-            return provider.transcribe(variant, audio_file_path, sample, use_url=use_url, language=language)
+            return provider.transcribe(variant, audio_file_path, sample, **kwargs)
         except PermanentError:
             raise
         except Exception as e:
@@ -100,6 +104,7 @@ def transcribe_dataset(
     use_url=False,
     max_samples=None,
     max_workers=4,
+    prompt=None,
 ):
     if use_url:
         audio_rows = fetch_audio_urls(dataset_path, config_name, split)
@@ -128,7 +133,7 @@ def transcribe_dataset(
             start = time.time()
             try:
                 transcription = transcribe_with_retry(
-                    model_name, None, sample, use_url=True, language=language
+                    model_name, None, sample, use_url=True, language=language, prompt=prompt
                 )
             except Exception as e:
                 print(f"Failed to transcribe after retries: {e}")
@@ -151,7 +156,7 @@ def transcribe_dataset(
             start = time.time()
             try:
                 transcription = transcribe_with_retry(
-                    model_name, tmp_path, sample, use_url=False, language=language
+                    model_name, tmp_path, sample, use_url=False, language=language, prompt=prompt
                 )
             except Exception as e:
                 print(f"Failed to transcribe after retries: {e}")
@@ -252,6 +257,12 @@ if __name__ == "__main__":
         action="store_true",
         help="Use URL-based audio fetching instead of datasets",
     )
+    parser.add_argument(
+        "--prompt",
+        type=str,
+        default=None,
+        help="Optional prompt to pass to the provider (e.g., 'Output must be in lexical format.')",
+    )
 
     args = parser.parse_args()
 
@@ -264,4 +275,5 @@ if __name__ == "__main__":
         use_url=args.use_url,
         max_samples=args.max_samples,
         max_workers=args.max_workers,
+        prompt=args.prompt,
     )

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,3 +4,5 @@ evaluate
 datasets
 librosa
 jiwer
+num2words
+soundfile


### PR DESCRIPTION
## Description
Add Microsoft Azure Speech API for EN and ML benchmark. Long-form eval is not supported.
Usage:
```cd api/```
update api key in the following two scripts
```bash run_api.sh```
```bash run_api_ml.sh```

## Type of change
- [ ] New model API - Microsoft Azure Speech

## New Model Checklist

Please report your results (WER on each split, average WER, and RTFx):
EN:
| Dataset | microsoft/azure-speech-05-2026 |
|---------|---:|
| ami | 8.28 |
| earnings22 | 7.94 |
| gigaspeech | 8.79 |
| librispeech-clean | 1.54 |
| librispeech-other | 2.85 |
| spgispeech | 2.59 |
| voxpopuli | 5.28 |
| **avg** | **5.32** |

ML:
| Dataset | microsoft/azure-speech-05-2026 |
|---------|---:|
| fleurs_de | 2.00 |
| mcv_de | 1.89 |
| **AVG-de** | **1.95** |
| fleurs_fr | 2.86 |
| mcv_fr | 4.30 |
| mls_fr | 2.77 |
| **AVG-fr** | **3.31** |
| fleurs_it | 1.05 |
| mcv_it | 1.80 |
| mls_it | 4.86 |
| **AVG-it** | **2.57** |
| fleurs_es | 1.75 |
| mcv_es | 2.25 |
| mls_es | 2.81 |
| **AVG-es** | **2.27** |
| fleurs_pt | 2.45 |
| mls_pt | 3.71 |
| **AVG-pt** | **3.08** |
| **AVG-all** | **2.65** |

### My model is not in Transformers (yet 🙃)
- pip install -r requirements/requirements-api.txt
