### PR TITLE
Add support for Smallest AI's Pulse Pro STT model

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -52,3 +52,4 @@ from . import elevenlabs_provider
 from . import revai_provider
 from . import aquavoice_provider
 from . import zoom_provider
+from . import smallest_pro_provider

--- a/api/providers/smallest_pro_provider.py
+++ b/api/providers/smallest_pro_provider.py
@@ -1,0 +1,54 @@
+import os
+import requests
+from typing import Optional
+
+from . import APIProvider, PermanentError, register
+
+
+@register("smallestai-pro")
+class SmallestAIProProvider(APIProvider):
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+    ) -> str:
+        api_key = os.getenv("SMALLESTAI_API_KEY")
+        if not api_key or api_key == "your_api_key":
+            raise ValueError(
+                "SMALLESTAI_API_KEY environment variable not set, get your key at https://console.smallest.ai"
+            )
+        endpoint = "https://api.smallest.ai/waves/v1/stt/"
+        if use_url:
+            audio_url = sample["row"]["audio"][0]["src"]
+            response = requests.post(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={"url": audio_url},
+                params={"model": "pulse-pro"},
+                timeout=300,
+            )
+        else:
+            with open(audio_file_path, "rb") as audio_file:
+                audio_data = audio_file.read()
+            response = requests.post(
+                endpoint,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/octet-stream",
+                },
+                data=audio_data,
+                params={"model": "pulse-pro"},
+                timeout=300,
+            )
+        if response.status_code != 429 and 400 <= response.status_code < 500:
+            raise PermanentError(
+                f"Smallest AI API returned {response.status_code}: {response.text}"
+            )
+        response.raise_for_status()
+        return response.json().get("transcription", "") or "."

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -8,6 +8,7 @@ export ELEVENLABS_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export AQUAVOICE_API_KEY="your_api_key"
 export ZOOM_API_KEY="your_api_key"
+export SMALLESTAI_API_KEY="your_api_key"
 
 export HF_TOKEN="hf_your_key"
 
@@ -22,6 +23,7 @@ MODEL_IDs=(
     # "speechmatics/enhanced"
     # "aquavoice/avalon-v1-en"
     "zoom/scribe_v1" # please use --use_url
+    # "smallestai-pro/pulse-pro" # please use --use_url
 )
 
 MAX_WORKERS=32


### PR DESCRIPTION
- **Documentation:** https://docs.smallest.ai/waves/documentation/speech-to-text-pulse/overview
- **API Reference:** https://docs.smallest.ai/waves/documentation/speech-to-text-pulse/quickstart

- **Get an API key:** https://console.smallest.ai

Pulse Pro is an English-only pre-recorded transcription model.

## ESB Benchmark (WER ↓)

| Dataset | Pulse Pro |
|---|---:|
| AMI | 7.32 |
| Earnings22 | 9.04 |
| GigaSpeech | 9.52 |
| LibriSpeech clean | 1.73 |
| LibriSpeech other | 3.74 |
| SPGISpeech | 2.04 |
| TED-LIUM | 3.68 |
| VoxPopuli | 6.32 |
| **Average (8 datasets)** | **5.42** |

Pulse Pro achieves a 5.42% average WER across the ESB benchmark.

Happy to provide a dedicated API key for evaluation — let me know the best way to share it.