### PR TITLE
higgs_audio: updated bosonai/higgs-audio-v3-stt weights (1.7B-class) — request re-evaluation

### DIFF
--- a/higgs_audio/run_higgs_audio.sh
+++ b/higgs_audio/run_higgs_audio.sh
@@ -4,16 +4,16 @@ export PYTHONPATH="..":$PYTHONPATH
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODELS=(
-    "bosonai/higgs-audio-v3-8b-stt-v2"
+    "bosonai/higgs-audio-v3-stt"
 )
 
 # Default batch size; per-dataset override allowed in DATASET_CONFIGS.
-BATCH_SIZE=64
+BATCH_SIZE=32
 
 # ── Datasets: "name split [batch_size]" (comment / uncomment to select) ──────
 # VoxPopuli has longer audio, so we use a smaller batch size to fit in VRAM.
 DATASET_CONFIGS=(
-    "voxpopuli test 32"
+    "voxpopuli test 16"
     "ami test"
     "earnings22 test"
     "gigaspeech test"


### PR DESCRIPTION
We have updated the weights of `bosonai/higgs-audio-v3-stt` (1.7B-class:
Whisper-large-v3 encoder + Qwen3-1.7B decoder, 2.68B params) in place and
would appreciate a re-evaluation of its leaderboard entry. This PR points
`higgs_audio/run_higgs_audio.sh` at it and sets batch 32 with VoxPopuli at 16
(VP is batch-size sensitive, same as noted for the 8B entry).

## What changed vs the previous checkpoint

- Training-data refresh: public train splits of AMI (IHM), VoxPopuli (en),
  SPGISpeech, LibriSpeech, TED-LIUM, GigaSpeech, plus the public Earnings22
  train split (`sanchit-gandhi/earnings22_split`), filtered to drop every row
  whose source recording appears in this leaderboard's E22 test set.
- `transcribe.py` post-processing: alongside the existing `_fix_repetitions`
  word-repetition cap, the updated repo adds a deterministic, content-blind
  collapse of degenerate consecutive n-gram loops (n ≤ 16, repeats > 2),
  applied uniformly to every dataset (implemented inline in `transcribe.py`;
  standalone reference in `ngram_loop_fix.py`).

## Reproduction

`bash higgs_audio/run_higgs_audio.sh` with this PR's config. We ran the full
suite through this batched path on our side before submitting (A100-80GB,
transformers 4.51.0, torch 2.5.1+cu121) and are happy to share our outputs
for cross-checking once you have yours — per the #135 lesson we'd rather the
official numbers come from your run. Thanks @ebezzam!

## Leakage controls

Training uses HF train splits only. The E22 public-split source-file filter
is part of the training loader; a train/test overlap audit
(meeting/source/segment/document/speaker/chapter level for all 8 datasets)
found zero structural overlap.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
