### PR TITLE
Add PyAI Hear — commercial streaming STT API for voice agents

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -55,3 +55,4 @@ from . import zoom_provider
 from . import smallest_provider
 from . import reson8_provider
 from . import microsoft_azure_provider
+from . import pyai_provider

--- a/api/providers/pyai_provider.py
+++ b/api/providers/pyai_provider.py
@@ -1,0 +1,76 @@
+import os
+import time
+from io import BytesIO
+from typing import Optional
+
+import requests
+
+from . import APIProvider, PermanentError, register
+
+PYAI_API_BASE = "https://api.pyai.com"
+
+
+@register("pyai")
+class PyAIProvider(APIProvider):
+    """PyAI Hear — streaming STT API for voice agents.
+
+    API docs: https://api.pyai.com/docs
+    Sign up for 1,000,000 free minutes/month: https://api.pyai.com
+
+    Set env var: PYAI_API_KEY
+    Model variants:
+      pyai/hear-v4   — production model (streaming-optimised FastConformer-TDT)
+    """
+
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+        **kwargs,
+    ) -> str:
+        api_key = os.getenv("PYAI_API_KEY")
+        if not api_key:
+            raise PermanentError("PYAI_API_KEY environment variable not set")
+
+        headers = {"Authorization": f"Bearer {api_key}"}
+
+        if use_url:
+            audio_url = sample["row"]["audio"][0]["src"]
+            resp = requests.get(audio_url, timeout=30)
+            if not resp.ok:
+                raise PermanentError(f"Failed to fetch audio URL: {resp.status_code}")
+            audio_bytes = BytesIO(resp.content)
+            filename = "audio.wav"
+        else:
+            audio_bytes = open(audio_file_path, "rb")
+            filename = os.path.basename(audio_file_path)
+
+        try:
+            response = requests.post(
+                f"{PYAI_API_BASE}/v1/audio/transcriptions",
+                headers=headers,
+                files={"file": (filename, audio_bytes, "audio/wav")},
+                data={
+                    "model": model_variant,
+                    "language": language,
+                    "response_format": "json",
+                },
+                timeout=120,
+            )
+        finally:
+            if not use_url:
+                audio_bytes.close()
+
+        if response.status_code == 401:
+            raise PermanentError(f"PyAI auth error: {response.text}")
+        if response.status_code == 429:
+            # Rate limited — let the retry loop handle it
+            raise Exception(f"PyAI rate limit (429): {response.text}")
+        if not response.ok:
+            raise Exception(f"PyAI API error {response.status_code}: {response.text}")
+
+        result = response.json()
+        return result.get("text", "")

--- a/api/run_pyai.sh
+++ b/api/run_pyai.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Evaluate PyAI Hear on the Open ASR Leaderboard benchmarks.
+# Sign up for a free API key at https://api.pyai.com (1M free min/month).
+
+export PYTHONPATH="..":$PYTHONPATH
+export PYAI_API_KEY="your_pyai_api_key"
+export HF_TOKEN="hf_your_key"
+
+MODEL_IDs=(
+    "pyai/hear-v4"
+)
+
+MAX_WORKERS=10
+DATASET_PATH="hf-audio/open-asr-leaderboard"
+
+declare -a EVAL_DATASETS=(
+    "ami:test"
+    "earnings22:test"
+    "gigaspeech:test"
+    "librispeech:test.clean"
+    "librispeech:test.other"
+    "spgispeech:test"
+    "tedlium:test"
+    "voxpopuli:test"
+    "common_voice:test"
+)
+
+for MODEL_ID in "${MODEL_IDs[@]}"; do
+    for DATASET_SPLIT in "${EVAL_DATASETS[@]}"; do
+        DATASET=$(echo $DATASET_SPLIT | cut -d: -f1)
+        SPLIT=$(echo $DATASET_SPLIT | cut -d: -f2)
+
+        echo "Evaluating $MODEL_ID on $DATASET ($SPLIT)..."
+        python run_eval.py \
+            --model_id "$MODEL_ID" \
+            --dataset_path "$DATASET_PATH" \
+            --dataset "$DATASET" \
+            --split "$SPLIT" \
+            --max_workers "$MAX_WORKERS" \
+            --device "cpu" \
+            2>&1 | tee "logs/${MODEL_ID//\//_}_${DATASET}_${SPLIT}.log"
+    done
+done


### PR DESCRIPTION
## What this adds

**PyAI Hear** is a production streaming ASR model/API optimised for real-time voice-agent telephony applications, built by [PyAI / Atoms AI](https://api.pyai.com).

- **API endpoint**: `api.pyai.com/v1/audio/transcriptions` (OpenAI-compatible)
- **Model variant**: `pyai/hear-v4` (FastConformer-TDT architecture, streaming-optimised)
- **Free tier**: $50 credit on signup + $5 credit every month — maintainers can use this to run evaluation at no cost
- **Trial**: 10,000 free minutes/month
- **Auth**: `PYAI_API_KEY` env var

## Files changed

- `api/providers/pyai_provider.py` — provider implementation (standard `APIProvider` interface, retry-safe 429/401 handling)
- `api/providers/__init__.py` — registered under prefix `pyai`
- `api/run_pyai.sh` — convenience eval script for all benchmark datasets

## Requesting maintainer-assisted evaluation

We'd like to be included in the leaderboard. If the maintainers can run `api/run_pyai.sh` with a `PYAI_API_KEY` (we can provide one via DM / issue), the $50 signup credit covers the full eval run.

Alternatively, if there's a preferred process for commercial API providers, happy to follow it.

## Coming soon — PyAI Omni (Speech-to-Speech)

We're also launching **PyAI Omni** shortly — an end-to-end speech-to-speech model trained specifically for telephony, with built-in conversational brain and voice cloning support. Happy to share early access if that's something the leaderboard would want to benchmark in the future (we're not aware of an existing S2S evaluation track — would love to help define one).

## Provider implementation notes

- Uses the OpenAI-compatible `/v1/audio/transcriptions` endpoint (multipart POST)
- `PermanentError` raised on 401 (bad key) — not retried
- 429 raised as regular `Exception` — retried by the leaderboard's retry loop
- `use_url=True` path fetches audio from HF datasets server and sends bytes directly