### PR TITLE
Correct abbreviation for 'flyer / flier'

### DIFF
--- a/normalizer/english_abbreviations.py
+++ b/normalizer/english_abbreviations.py
@@ -604,7 +604,7 @@ english_spelling_normalizer = {
   "flavourless": "flavorless",
   "flavours": "flavors",
   "flavoursome": "flavorsome",
-  "flyer / flier": "flier / flyer",
+  "flyer": "flier",
   "foetal": "fetal",
   "foetid": "fetid",
   "foetus": "fetus",


### PR DESCRIPTION
The spelling mapping for flyer -> flier was copies as the verbatim "flyer / flier" and "flier / flyer" strings. The spaces and slashes will cause this to never be matched by the normalizer.

Changing to "flyer: flier" to allow the matcher to work as intended.
