### PR TITLE
Add assembly/universal-3-5-pro (AssemblyAI Universal-3.5 Pro)

### DIFF
--- a/api/providers/assemblyai_provider.py
+++ b/api/providers/assemblyai_provider.py
@@ -20,7 +20,7 @@ class AssemblyAIProvider(APIProvider):
         transcriber = aai.Transcriber()
 
         # Models like "universal-3-pro" use the newer speech_models (list) API
-        MULTI_MODEL_VARIANTS = {"universal-3-pro"}
+        MULTI_MODEL_VARIANTS = {"universal-3-pro", "universal-3-5-pro"}
         if model_variant in MULTI_MODEL_VARIANTS:
             config = aai.TranscriptionConfig(
                 speech_models=[model_variant],

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -24,6 +24,7 @@ MODEL_CONFIGS=(
     # "openai/gpt-4o-mini-transcribe false  16"
     # "openai/whisper-1              false  16"
     # "assembly/universal-3-pro      false  4"
+    # "assembly/universal-3-5-pro    false  4"
     # "elevenlabs/scribe_v1          false  16"
     # "revai/machine                 false  4"
     # "revai/fusion                  false  4"

--- a/api/submit_jobs.sh
+++ b/api/submit_jobs.sh
@@ -31,6 +31,7 @@ MODEL_CONFIGS=(
     # "openai/gpt-4o-mini-transcribe false  16"
     # "openai/whisper-1              false  16"
     # "assembly/universal-3-pro      false  4"   # `cpu-xl` needed for spgispeech
+    # "assembly/universal-3-5-pro    false  4"   # `cpu-xl` needed for spgispeech
     # "elevenlabs/scribe_v1          false  16"
     # "revai/machine                 false  8"
     # "revai/fusion                  false  8"


### PR DESCRIPTION
## Description

Adds AssemblyAI **Universal-3.5 Pro** as a new API model: `assembly/universal-3-5-pro`.

It routes through AssemblyAI's `speech_models=[...]` list API — the **same path the existing `assembly/universal-3-pro` already uses** — so the change is a one-line addition to the provider's multi-model variant set, plus commented config entries in the API run scripts. No `run_eval.py` / Dockerfile / normalizer changes are needed.

Evaluated **out-of-the-box** (no `prompt`/`keyterms_prompt`), with `language_code="en"`, on the English short-form suite via **HF Jobs**.

Changed files:
- `api/providers/assemblyai_provider.py` — add `universal-3-5-pro` to `MULTI_MODEL_VARIANTS`
- `api/submit_jobs.sh`, `api/run_api.sh` — add commented config entries (matching the `universal-3-pro` template)

## Type of change
- [x] New model

## New Model Checklist

- [x] Results reported below (per-split WER, average WER, RTFx).
  - The `.eval_results/open_asr_leaderboard.yaml`-in-model-repo step is **N/A**: Universal-3.5 Pro is a proprietary API with no HF Hub model repo (same as the existing `assembly/universal-3-pro` entry).

### HF Jobs evaluation
- [x] Reproducible Space (duplicated from `hf-audio/open-asr-leaderboard-apis` with the one-line provider change): **https://huggingface.co/spaces/dlange00/open-asr-leaderboard-apis** (public). All datasets below were run on HF Jobs from this Space.
- [x] `submit_jobs.sh` entry added under `api/` (the existing API-model library folder); no new folder needed since `assembly` is an existing provider.
- [x] No `trust_remote_code` / revision pinning needed (API model).

### Key guidelines
- [x] **Same decoding hyper-parameters across all datasets** — out-of-the-box, `language_code="en"`, no prompt/keyterms.
- [x] `run_eval.py` supports batch processing and uses `normalizer/data_utils.py` (existing `api/run_eval.py`, unchanged).
- [ ] **API model → API key for maintainers:** AssemblyAI will provide an API key out-of-band so maintainers can reproduce on HF Jobs and run the private datasets.
- [x] Results on public sets + RTFx reported below.
- [x] Model metadata:

| License | Size (B) | # Languages | Encoder | Decoder |
|---|---|---|---|---|
| Proprietary | N/A (undisclosed) | 18 | N/A | N/A |

## Results — English short-form (HF Jobs; `cpu-basic`, `cpu-xl` for spgispeech)

| Dataset | WER | RTFx |
|---|---:|---:|
| LibriSpeech test.clean | 1.56 | 1.80 |
| SPGISpeech | 2.02 | 2.25 |
| LibriSpeech test.other | 2.65 | 1.60 |
| VoxPopuli | 6.85 | 2.23 |
| GigaSpeech | 8.42 | 1.46 |
| Earnings22 | 10.43 | 1.77 |
| AMI | 12.69 | 0.62 |
| TEDLIUM | — | — (see note below) |
| **Average (7 sets, excl. TEDLIUM)** | **6.37** | — |

For reference, this improves on `universal-3-pro` on the same 7 sets (6.37 vs 6.66), with the largest gain on AMI. AMI/Earnings22 were cross-checked against an independent local run and matched within ~0.1–0.2 WER.

> RTFx here is measured under our HF Jobs concurrency for an async (pre-recorded) API, so — like other API entries — it is not a GPU-throughput figure.

## ⚠️ TEDLIUM could not be evaluated — the dataset config appears broken

`load_dataset("hf-audio/open-asr-leaderboard", "tedlium", split="test")` fails because the `tedlium` config has **no data files** in the dataset repo, even though it declares `test = 1155 examples / ~301 MB`:

- Non-streaming → `NonMatchingSplitsSizesError` (expected 1155 examples, **recorded 0**).
- Streaming → 0 rows / empty references → `ZeroDivisionError` when computing WER.

Every other config (voxpopuli, librispeech, ami, …) has its `test-*.parquet` shards; `tedlium` has **zero files**. This blocks TEDLIUM scoring for **all** models, not just this one. Could the `tedlium` `test-*.parquet` shards be re-uploaded to `hf-audio/open-asr-leaderboard`? We're happy to re-run to complete the 8-dataset average once it's fixed.

## Related issues
<!-- link a dataset issue here if opened -->
