### PR TITLE
Modulate vfast provider

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 class PermanentError(Exception):
     """Error that should not be retried (e.g., URL fetch failure)."""
+
     pass
 
 
@@ -27,9 +28,11 @@ _REGISTRY: dict[str, type[APIProvider]] = {}
 
 def register(prefix: str):
     """Decorator to register a provider class under a model prefix."""
+
     def decorator(cls: type[APIProvider]):
         _REGISTRY[prefix] = cls
         return cls
+
     return decorator
 
 
@@ -37,7 +40,7 @@ def get_provider(model_name: str) -> tuple[APIProvider, str]:
     """Look up provider by model_name prefix, return (provider_instance, variant)."""
     for prefix, cls in _REGISTRY.items():
         if model_name.startswith(prefix + "/"):
-            variant = model_name[len(prefix) + 1:]
+            variant = model_name[len(prefix) + 1 :]
             return cls(), variant
     raise ValueError(
         f"No provider registered for model '{model_name}'. "
@@ -46,13 +49,6 @@ def get_provider(model_name: str) -> tuple[APIProvider, str]:
 
 
 # Auto-import all provider modules so they register themselves
-from . import speechmatics_provider
-from . import assemblyai_provider
-from . import openai_provider
-from . import elevenlabs_provider
-from . import revai_provider
-from . import aquavoice_provider
-from . import zoom_provider
-from . import smallest_provider
-from . import reson8_provider
-from . import microsoft_azure_provider
+from . import (
+    modulate_provider,
+)  # aquavoice_provider,; assemblyai_provider,; elevenlabs_provider,; microsoft_azure_provider,; openai_provider,; reson8_provider,; revai_provider,; smallest_provider,; speechmatics_provider,; zoom_provider,

--- a/api/providers/modulate_provider.py
+++ b/api/providers/modulate_provider.py
@@ -1,0 +1,68 @@
+import os
+from typing import Optional
+
+import requests
+
+from . import APIProvider, PermanentError, register
+
+
+@register("modulate")
+class ModulateProvider(APIProvider):
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+        prompt: Optional[str] = None,
+    ) -> str:
+        endpoint = os.getenv("MODULATE_ENDPOINT")
+        if not endpoint:
+            raise PermanentError(
+                "MODULATE_ENDPOINT is not set. Export the full endpoint URL, e.g. "
+                "https://platform.modulate.ai/api/velma-2-stt-batch-english-vfast"
+            )
+        api_key = os.getenv("MODULATE_API_KEY")
+        if not api_key:
+            raise PermanentError("MODULATE_API_KEY is not set.")
+
+        # URL mode is not supported by the Modulate file-upload API.
+        if use_url:
+            raise PermanentError(
+                "Modulate provider supports file mode only; run without --use_url."
+            )
+
+        audio_duration = (
+            len(sample["audio"]["array"]) / sample["audio"]["sampling_rate"]
+        )
+        if audio_duration < 0.0:
+            print(f"Skipping audio duration {audio_duration}s")
+            return "."
+
+        if audio_file_path is None:
+            raise PermanentError("audio_file_path is required in file mode.")
+
+        headers = {"X-API-Key": api_key}
+        with open(audio_file_path, "rb") as fh:
+            files = {"upload_file": (os.path.basename(audio_file_path), fh)}
+            response = requests.post(
+                endpoint, headers=headers, files=files, timeout=600
+            )
+
+        # A 4xx is a request/auth problem - permanent, do not retry.
+        if 400 <= response.status_code < 500:
+            raise PermanentError(
+                f"Modulate endpoint rejected the request "
+                f"(HTTP {response.status_code}): {response.text[:200]}"
+            )
+        # Any other non-200 (incl. 5xx / 502 from the ensemble gate) is transient;
+        # raise a plain exception so run_eval.py's retry loop re-sends the clip.
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Modulate endpoint HTTP {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+
+        body = response.json()
+        return body.get("text") or ""

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -34,6 +34,7 @@ MODEL_CONFIGS=(
     # "reson8/resonant-1             false  16"
     # "reson8/resonant-1-flash       false  16"
     # "microsoft/azure-speech-05-2026  false  4"
+    "modulate/vfast   false  16"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -12,6 +12,7 @@ export AZURE_API_KEY="your_api_key"
 export REVAI_API_KEY="your_api_key"
 export ZOOM_API_KEY="your_api_key"
 export OPENAI_API_KEY="your_api_key"
+export MODULATE_API_KEY="your_api_key"
 
 export HF_TOKEN="your_api_key"
 RESULTS_BUCKET="${RESULTS_BUCKET:-}"
@@ -34,7 +35,7 @@ MODEL_CONFIGS=(
     # "reson8/resonant-1             false  16"
     # "reson8/resonant-1-flash       false  16"
     # "microsoft/azure-speech-05-2026  false  4"
-    "modulate/vfast   false  16"
+    "modulate/vfast   false  100"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -35,7 +35,7 @@ MODEL_CONFIGS=(
     # "reson8/resonant-1             false  16"
     # "reson8/resonant-1-flash       false  16"
     # "microsoft/azure-speech-05-2026  false  4"
-    "modulate/vfast   false  100"
+    "modulate/vfast   false  20"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -35,7 +35,7 @@ MODEL_CONFIGS=(
     # "reson8/resonant-1             false  16"
     # "reson8/resonant-1-flash       false  16"
     # "microsoft/azure-speech-05-2026  false  4"
-    "modulate/vfast   false  20"
+    "modulate/vfast   false  25"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 


### PR DESCRIPTION
## Description

Adds **Modulate `velma-2-stt-batch-english-vfast`** as a new API model: `modulate/vfast`, submitted to the **English short-form track**.

It is evaluated through Modulate's hosted endpoint (proprietary / API lane): `run_eval.py` loads each dataset, calls the provider for every clip, and computes WER; the provider uploads the clip to the endpoint and the endpoint returns a transcript. This PR adds a new API provider and a run-script entry; it does not change `run_eval.py`, the Dockerfile, or the normalizer.

**How to run / reproduce (self-service — no key request needed):**

1. Create an account at **https://platform.modulate.ai/signin**
2. Generate an API key in the dashboard. New accounts receive free credit sufficient to cover a full run across all 7 datasets, with headroom to spare.
3. In `run_api.sh`, set your key on the Modulate line, replacing the placeholder (the script assigns its API keys inline). The endpoint is set automatically by the provider — no endpoint configuration is required:

```bash
export MODULATE_API_KEY="<your generated key>"
```

4. Run `bash run_api.sh` (the `modulate/vfast` entry is already enabled in `MODEL_CONFIGS`).

Evaluated **out-of-the-box**: English, no prompt or per-dataset decoding overrides.

Changed files:

- `providers/modulate_provider.py` — new API provider (file-upload lane; the endpoint defaults internally to the public URL).
- `providers/__init__.py` — one-line registration (`from . import modulate_provider`).
- `run_api.sh` — add the `modulate/vfast` entry to `MODEL_CONFIGS`.
- `requirements/requirements-api.txt` — add `requests`.

## Type of change

- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

- [x] Report results (WER per split, average WER, RTFx) — see below.
  - The HF-Hub `.eval_results/open_asr_leaderboard.yaml` step is **N/A**: `modulate/vfast` is a proprietary API with no model repo on the HF Hub.

### HF Jobs evaluation (recommended)

This is an **API-lane** entry: the model is a hosted endpoint, so there is no local checkpoint, Dockerfile, or `run_eval.py` change to package into a Space. Reproduction is fully self-service against the public endpoint (see the run steps in the Description). Happy to prepare/duplicate a Space or provide a key directly if the maintainers prefer that route for HF Jobs verification.

- [ ] (Custom Space) — N/A for this API entry (no custom dependencies/Dockerfile).
  - [ ] Modify `Dockerfile` — N/A (no local model).
  - [ ] Adapt `run_eval.py` — N/A (uses the existing API `run_eval.py`, unchanged).
  - [ ] `trust_remote_code` / `revision` — N/A (API model, no remote code).
- [ ] Model-library folder + `submit_jobs.sh` — N/A (uses the existing API run script; `modulate` is a new provider under the existing API path).

### Key guidelines

- [x] **Same decoding hyper-parameters across all datasets** — out-of-the-box, English, no prompt / keyterms / per-dataset overrides.
- [x] `run_eval.py` supports batch processing and uses the repo's data/normalizer utilities (unchanged).
- [ ] Maximum batch size on an H200 — N/A (hosted API; not run on a local GPU).
- [ ] `torch.compile` / warmup — N/A (hosted API).
- [x] **API model → API key:** verification is self-service — maintainers create an account at the link above and generate their own key; free credit covers the full public run and the private datasets, so no waiting on us. We can also provide a key directly if preferred.
- [ ] HF Space for HF Jobs reproduction — see the note above; happy to prepare one on request.
- [x] Results on the public sets + RTFx reported below.
- [x] Model metadata:

| License | Size (B) | # Languages | Encoder | Decoder |
| --- | --- | --- | --- | --- |
| Proprietary | N/A (hosted API) | 1 (English) | N/A | N/A |

## Results — English short-form 

Per-split WER and RTFx as reported by the harness on this run.

| Dataset | WER | RTFx |
| --- | --- | --- |
| LibriSpeech test.clean | 0.94 | 1.25 |
| LibriSpeech test.other | 1.88 | 1.20 |
| SPGISpeech | 2.41 | 1.33 |
| VoxPopuli | 5.13 | 1.41 |
| GigaSpeech | 7.30 | 1.13 |
| AMI | 7.40 | 0.97 |
| Earnings22 | 8.11 | 1.02 |
| **Average (7 sets)** | **4.74** | **1.24** |

Run-to-run composite variance on this system is small (a few hundredths of a point); the reported average is **4.74**.

## Results — English short-form (updated cleaned splits)
 
Per-split WER and RTFx as reported by the harness (`score_results`) on this run, using the updated `ami_cleaned` / `gigaspeech_cleaned` / `voxpopuli_cleaned_aa` splits.
 
| Dataset | WER | RTFx |
| --- | --- | --- |
| LibriSpeech test.clean | 0.92 | 0.77 |
| LibriSpeech test.other | 1.89 | 0.76 |
| SPGISpeech | 2.41 | 0.82 |
| VoxPopuli (cleaned_aa) | 3.77 | 0.81 |
| AMI (cleaned) | 6.71 | 0.68 |
| GigaSpeech (cleaned) | 7.27 | 0.76 |
| Earnings22 | 8.08 | 0.62 |
| **Average (7 sets)** | **4.44** | **0.79** |
 
Run-to-run composite variance on this system is small (a few hundredths of a point); the reported average is **4.44**. Verified clean: all clips transcribed, no empty predictions.


> RTFx here is measured end-to-end through the hosted API under our serving concurrency for an async (pre-recorded) API, so — like other API entries — it is not a GPU-throughput figure and is not directly comparable to local open-weights RTFx on reference hardware. WER is the directly comparable metric.

