### PR TITLE
Add SoundsGoodAI Zipformer-XL CR-CTC Transducer

### DIFF
--- a/soundsgoodai/run_zipformer.sh
+++ b/soundsgoodai/run_zipformer.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-MODEL_ID="soundsgoodai/Zipformer-transducer-XL-290M"
+MODEL_ID="soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M"
 BATCH_SIZE=64
 DEVICE_ID=0
 ICEFALL_PATH="./icefall"

--- a/soundsgoodai/submit_jobs.sh
+++ b/soundsgoodai/submit_jobs.sh
@@ -12,6 +12,7 @@ ORG_NAME="${ORG_NAME:-}"
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
     "soundsgoodai/Zipformer-transducer-XL-290M 64"
+    "soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M 64"
 )
 
 # ── Datasets: "name split" ────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Adds a new SoundsGoodAI Zipformer XL model, trained with an auxiliary CR-CTC loss, to the Open ASR Leaderboard.

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

I haven't added cleaned results for Ami, Gigaspeech and Voxpopuli open_asr_leaderboard.yaml, do I have to add them?

### HF Jobs evaluation (recommended)

A model was evaluated using HF jobs against every testset from a conventional past list, plus new cleaned versions for Ami, Gigaspeech and Voxpopuli (see https://github.com/huggingface/open_asr_leaderboard/pull/178). Model outputs are saved to the bucket https://huggingface.co/buckets/soundsgoodai/ASR_results/tree/soundsgoodai-Zipformer-cr-ctc-transducer-XL-290M

### Results

All jobs finished for soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M.
All 10 result files present.
Filtering models by id: soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M
********************************************************************************
Results per dataset:
********************************************************************************
Zipformer-cr-ctc-transducer-XL-290M | ami_cleaned_test:                 **WER = 10.28 %, RTFx = 155.59**
Zipformer-cr-ctc-transducer-XL-290M | ami_test:                                **WER = 11.30 %, RTFx = 152.35**
Zipformer-cr-ctc-transducer-XL-290M | earnings22_test:                   **WER = 7.64 %, RTFx = 158.38**
Zipformer-cr-ctc-transducer-XL-290M | gigaspeech_cleaned_test:   **WER = 8.32 %, RTFx = 154.71**
Zipformer-cr-ctc-transducer-XL-290M | gigaspeech_test:                   **WER = 8.41 %, RTFx = 138.60**
Zipformer-cr-ctc-transducer-XL-290M | librispeech_test.clean:          **WER = 1.31 %, RTFx = 158.07**
Zipformer-cr-ctc-transducer-XL-290M | librispeech_test.other:          **WER = 3.01 %, RTFx = 160.80**
Zipformer-cr-ctc-transducer-XL-290M | spgispeech_test:                   **WER = 1.64 %, RTFx = 150.43**
Zipformer-cr-ctc-transducer-XL-290M | voxpopuli_cleaned_aa_test: **WER = 4.29 %, RTFx = 151.82**
Zipformer-cr-ctc-transducer-XL-290M | voxpopuli_test:                      **WER = 5.60 %, RTFx = 149.11**

********************************************************************************
Composite Results:
********************************************************************************
soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M: WER = 6.18 %
soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M: RTFx = 149.85
********************************************************************************

********************************************************************************
CSV Summary (Public):
********************************************************************************
avg WER (soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M) = 5.21
model,RTFx,License,Size (B),# Languages,Encoder,Decoder,AMI-Cleaned WER,Earnings22 WER,Gigaspeech-Cleaned WER,LS Clean WER,LS Other WER,SPGISpeech WER,Voxpopuli-Cleaned-AA WER
soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M,152.45,,,,,,10.28,7.64,8.32,1.31,3.01,1.64,4.29
********************************************************************************

********************************************************************************
CSV Summary (Extra):
********************************************************************************
avg WER (soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M) = 8.44
model,AMI WER,Gigaspeech WER,Voxpopuli WER
soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M,11.3,8.41,5.6
********************************************************************************

**AVG WER public leaderboard 5.21**