### PR TITLE
Add multilingual variant: point at velma-2-stt-batch-multilingual-vfa…

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 class PermanentError(Exception):
     """Error that should not be retried (e.g., URL fetch failure)."""
+
     pass
 
 
@@ -27,9 +28,11 @@ _REGISTRY: dict[str, type[APIProvider]] = {}
 
 def register(prefix: str):
     """Decorator to register a provider class under a model prefix."""
+
     def decorator(cls: type[APIProvider]):
         _REGISTRY[prefix] = cls
         return cls
+
     return decorator
 
 
@@ -37,7 +40,7 @@ def get_provider(model_name: str) -> tuple[APIProvider, str]:
     """Look up provider by model_name prefix, return (provider_instance, variant)."""
     for prefix, cls in _REGISTRY.items():
         if model_name.startswith(prefix + "/"):
-            variant = model_name[len(prefix) + 1:]
+            variant = model_name[len(prefix) + 1 :]
             return cls(), variant
     raise ValueError(
         f"No provider registered for model '{model_name}'. "
@@ -46,15 +49,17 @@ def get_provider(model_name: str) -> tuple[APIProvider, str]:
 
 
 # Auto-import all provider modules so they register themselves
-from . import speechmatics_provider
-from . import assemblyai_provider
-from . import openai_provider
-from . import elevenlabs_provider
-from . import revai_provider
-from . import aquavoice_provider
-from . import zoom_provider
-from . import smallest_provider
-from . import reson8_provider
-from . import microsoft_azure_provider
-from . import modulate_provider
-from . import gladia_provider
+from . import (
+    aquavoice_provider,
+    assemblyai_provider,
+    elevenlabs_provider,
+    gladia_provider,
+    microsoft_azure_provider,
+    modulate_provider,
+    openai_provider,
+    reson8_provider,
+    revai_provider,
+    smallest_provider,
+    speechmatics_provider,
+    zoom_provider,
+)

--- a/api/providers/modulate_provider.py
+++ b/api/providers/modulate_provider.py
@@ -5,11 +5,11 @@ import requests
 
 from . import APIProvider, PermanentError, register
 
-
 MODEL_VARIANT_TO_ENDPOINT = {
     "vfast": "https://platform.modulate.ai/api/velma-2-stt-batch-english-vfast",
-    "multilingual": "https://platform.modulate.ai/api/velma-2-stt-batch",
+    "multilingual": "https://platform.modulate.ai/api/velma-2-stt-batch-multilingual-vfast",
 }
+
 
 @register("modulate")
 class ModulateProvider(APIProvider):
@@ -27,7 +27,10 @@ class ModulateProvider(APIProvider):
                 f"Unknown Modulate model variant '{model_variant}'. "
                 f"Known variants: {list(MODEL_VARIANT_TO_ENDPOINT)}"
             )
-        endpoint = os.getenv("MODULATE_ENDPOINT", MODEL_VARIANT_TO_ENDPOINT[model_variant])
+
+        endpoint = os.getenv(
+            "MODULATE_ENDPOINT", MODEL_VARIANT_TO_ENDPOINT[model_variant]
+        )
         api_key = os.getenv("MODULATE_API_KEY")
         if not api_key:
             raise PermanentError("MODULATE_API_KEY is not set.")
@@ -49,10 +52,19 @@ class ModulateProvider(APIProvider):
             raise PermanentError("audio_file_path is required in file mode.")
 
         headers = {"X-API-Key": api_key}
+
+        # Multilingual endpoint takes an optional `language` form field (short
+        # ISO code, e.g. de/es/fr/it/pt); providing it selects the declared-
+        # language path so the file routes straight to the language-best
+        # transcriber. The English endpoint ignores the field.
+        data = None
+        if model_variant == "multilingual" and language:
+            data = {"language": language.strip().lower()}
+
         with open(audio_file_path, "rb") as fh:
             files = {"upload_file": (os.path.basename(audio_file_path), fh)}
             response = requests.post(
-                endpoint, headers=headers, files=files, timeout=600
+                endpoint, headers=headers, files=files, data=data, timeout=600
             )
 
         # A 4xx is a request/auth problem - permanent, do not retry.
@@ -61,6 +73,7 @@ class ModulateProvider(APIProvider):
                 f"Modulate endpoint rejected the request "
                 f"(HTTP {response.status_code}): {response.text[:200]}"
             )
+
         # Any other non-200 (incl. 5xx / 502 from the ensemble gate) is transient;
         # raise a plain exception so run_eval.py's retry loop re-sends the clip.
         if response.status_code != 200:

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -13,18 +13,20 @@ export AQUAVOICE_API_KEY="your_api_key"
 export SPEECHMATICS_API_KEY="your_api_key"
 export RESON8_API_KEY="your_api_key"
 export AZURE_API_KEY="your_api_key"
+export MODULATE_API_KEY="your_api_key"
 
 # Configuration
 MODEL_IDs=(
-    # "openai/gpt-4o-transcribe"
-    # "openai/gpt-4o-mini-transcribe"
-    # "openai/whisper-1"
-    # "assembly/universal-3-pro"
-    # "elevenlabs/scribe_v2"
-    # "speechmatics/enhanced"
+    "openai/gpt-4o-transcribe"
+    "openai/gpt-4o-mini-transcribe"
+    "openai/whisper-1"
+    "assembly/universal-3-pro"
+    "elevenlabs/scribe_v2"
+    "speechmatics/enhanced"
     "reson8/resonant-1"
     "reson8/resonant-1-flash"
     "microsoft/azure-speech-05-2026"
+    "modulate/multilingual"
 )
 
 MAX_WORKERS=20


### PR DESCRIPTION
## Description
 
Adds **`velma-2-stt-batch-multilingual-vfast`** (model id `modulate/multilingual`), Modulate's production multilingual speech-to-text service, to the **multilingual** track as an **API / proprietary-lane** entry. Follows the same pattern as our merged English entry (`velma-2-stt-batch-english-vfast`, model id `modulate/vfast`).
 
Each clip is sent to the hosted endpoint with its dataset language declared (short ISO code, e.g. `de`, `es`). Transcripts are scored by the repo's own multilingual scorer (`normalizer.eval_utils.score_results(..., multilingual=True)`).
 
**How to run:** set `MODULATE_API_KEY` (and optionally `MODULATE_ENDPOINT`), then run the multilingual eval with `--model_name=modulate/multilingual` over the 13 FLEURS/MCV/MLS configs (de, fr, it, es, pt).
 
**Self-reported results** (WER via the leaderboard's multilingual scorer; composite is the unweighted mean across the 13 configs):
 
| Dataset | Lang | WER |
| --- | --- | --- |
| FLEURS | de | 4.19% |
| FLEURS | fr | 4.86% |
| FLEURS | it | 3.23% |
| FLEURS | es | 3.77% |
| FLEURS | pt | 3.46% |
| MCV | de | 2.80% |
| MCV | es | 2.47% |
| MCV | fr | 4.74% |
| MCV | it | 2.38% |
| MLS | es | 1.68% |
| MLS | fr | 2.27% |
| MLS | it | 3.40% |
| MLS | pt | 4.88% |
| **Composite (mean)** | | **3.39%** |
 
RTFx: N/A (API lane — client-side RTFx is confounded by network/upload/serving hardware and not comparable to reference-GPU numbers, consistent with the other API entries on this track).
 
## Type of change
- [x] New model
## New Model Checklist
 
- [ ] ~Hub-hosted `.eval_results` yaml~ — N/A, proprietary API service, no model repo.
### HF Jobs evaluation
 
N/A for an API entry — no weights or dependencies to containerize. Reproduction is via the hosted endpoint (see API models below).
 
#### Key guidelines
- [x] Same decoding hyper-parameters across all datasets — identical config for every dataset and language, no per-dataset tuning.
- [x] Results reported on the public sets (table above). RTFx N/A (API lane).
- [x] Model metadata provided below.
License | Size (B) | # Languages | Encoder | Decoder
-- | -- | -- | -- | --
Proprietary | N/A (API) | 99 (5 evaluated here: de, fr, it, es, pt) | N/A (API) | N/A (API)
 
### API models
 
- [x] Will provide an API key to the maintainers privately on request (not posted in this PR). Free-credit self-service signup is available at `platform.modulate.ai/signin`, covering a full run.
- [x] Added `api/providers/modulate_provider.py` (the `multilingual` variant of the existing Modulate provider).
- [x] Provider is registered in `api/providers/__init__.py` (Modulate provider already registered from the merged English entry).
- [ ] `api/run_api.sh` — happy to add an explicit `MODEL_CONFIGS` line / `docker run` key-pass line in whichever run script the maintainers prefer for the multilingual track.
- [x] API documentation: <ADD PUBLIC DOCS URL>
- [x] Languages supported: 99 (this submission evaluates the 5 covered by the FLEURS/MCV/MLS sets: de, fr, it, es, pt)