### PR TITLE
Add Audio8-ASR-0.1B H200 evaluation jobs

### DIFF
--- a/audio8_asr/submit_jobs.sh
+++ b/audio8_asr/submit_jobs.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Independent Audio8-ASR HF Jobs submission.
+# Usage:
+#   RESULTS_BUCKET="AutoArk-AI/audio8-asr-open-asr-results" \
+#   HF_TOKEN="hf_..." \
+#   ORG_NAME="AutoArk-AI" \
+#   bash audio8_asr/submit_jobs.sh
+
+SPACE="${SPACE:-AutoArk-AI/open-asr-leaderboard-audio8-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:?Set RESULTS_BUCKET to a writable Hugging Face bucket}"
+DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+FLAVOR="${FLAVOR:-h200}"
+ORG_NAME="${ORG_NAME:-}"
+MODEL_ID="${MODEL_ID:-AutoArk-AI/Audio8-ASR-0.1B}"
+MODEL_REVISION="${MODEL_REVISION:-b812eff124893ecd76a1dcde74ee58db5adab59c}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-256}"
+MAX_AUDIO_SECONDS="${MAX_AUDIO_SECONDS:-30}"
+WARMUP_STEPS="${WARMUP_STEPS:-1}"
+FEATURE_WORKERS="${FEATURE_WORKERS:-16}"
+TORCH_COMPILE="${TORCH_COMPILE:-}"
+JOB_TIMEOUT="${JOB_TIMEOUT:-2h}"
+CUDA_ALLOC_CONF="${CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+DATASET_CONFIGS=(
+  "ami_cleaned test ${AMI_BATCH_SIZE:-1152}"
+  "earnings22 test ${EARNINGS22_BATCH_SIZE:-1024}"
+  "gigaspeech_cleaned test ${GIGASPEECH_BATCH_SIZE:-1408}"
+  "librispeech test.clean ${LIBRISPEECH_CLEAN_BATCH_SIZE:-1024}"
+  "librispeech test.other ${LIBRISPEECH_OTHER_BATCH_SIZE:-1024}"
+  "spgispeech test ${SPGISPEECH_BATCH_SIZE:-2048}"
+  "voxpopuli_cleaned_aa test ${VOXPOPULI_BATCH_SIZE:-628}"
+)
+
+if [[ -z "${HF_TOKEN:-}" ]]; then
+  echo "HF_TOKEN is required" >&2
+  exit 1
+fi
+
+MODEL_FOLDER="${MODEL_ID//\//-}"
+NAMESPACE_ARGS=()
+if [[ -n "$ORG_NAME" ]]; then
+  NAMESPACE_ARGS=(--namespace "$ORG_NAME")
+fi
+
+COMPILE_ARGS=""
+if [[ -n "$TORCH_COMPILE" ]]; then
+  COMPILE_ARGS="--torch_compile=${TORCH_COMPILE}"
+fi
+
+echo "Space: $SPACE"
+echo "Model: $MODEL_ID@$MODEL_REVISION"
+echo "Results bucket: $RESULTS_BUCKET"
+echo "Hardware: $FLAVOR"
+echo "Job timeout: $JOB_TIMEOUT"
+echo "CUDA allocator: $CUDA_ALLOC_CONF"
+
+pids=()
+for config in "${DATASET_CONFIGS[@]}"; do
+  read -r dataset split batch_size <<< "$config"
+  echo "Submitting dataset=${dataset} split=${split} batch_size=${batch_size}"
+  (
+    hf jobs run \
+      --flavor "$FLAVOR" \
+      --timeout "$JOB_TIMEOUT" \
+      --secrets HF_TOKEN \
+      --env HF_AUDIO_DECODER_BACKEND="soundfile" \
+      --env PYTORCH_CUDA_ALLOC_CONF="$CUDA_ALLOC_CONF" \
+      "${NAMESPACE_ARGS[@]}" \
+      --volume "hf://buckets/${RESULTS_BUCKET}:/results_bucket" \
+      "hf.co/spaces/${SPACE}" \
+      bash -c "
+        set -euo pipefail
+        cd /app
+        rm -rf /app/results
+        PYTHONPATH=/app python /app/run_eval.py \\
+          --model_id=${MODEL_ID} \\
+          --model_revision=${MODEL_REVISION} \\
+          --dataset_path=${DATASET_PATH} \\
+          --dataset=${dataset} \\
+          --split=${split} \\
+          --device=0 \\
+          --dtype=bfloat16 \\
+          --attn_implementation=eager \\
+          --batch_size=${batch_size} \\
+          --max_eval_samples=-1 \\
+          --max_new_tokens=${MAX_NEW_TOKENS} \\
+          --max_audio_seconds=${MAX_AUDIO_SECONDS} \\
+          --warmup_steps=${WARMUP_STEPS} \\
+          --feature_workers=${FEATURE_WORKERS} \\
+          --torch_cpu_threads=1 \\
+          ${COMPILE_ARGS}
+        mkdir -p /results_bucket/${MODEL_FOLDER}
+        cp /app/results/*.jsonl /results_bucket/${MODEL_FOLDER}/
+        cp /app/results/*.summary.json /results_bucket/${MODEL_FOLDER}/
+      "
+  ) &
+  pids+=("$!")
+done
+
+failed=0
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then
+    failed=1
+  fi
+done
+if [[ "$failed" -ne 0 ]]; then
+  echo "One or more HF Jobs failed" >&2
+  exit 1
+fi
+
+if [[ -n "$ORG_NAME" ]]; then
+  echo "Jobs page: https://huggingface.co/organizations/${ORG_NAME}/settings/jobs"
+else
+  echo "Jobs page: https://huggingface.co/settings/jobs"
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+local_results="$repo_root/results/$MODEL_FOLDER"
+mkdir -p "$local_results"
+hf buckets sync \
+  "hf://buckets/${RESULTS_BUCKET}/${MODEL_FOLDER}" \
+  "$local_results"
+
+actual="$(find "$local_results" -maxdepth 1 -name '*.jsonl' | wc -l)"
+expected="${#DATASET_CONFIGS[@]}"
+if [[ "$actual" -ne "$expected" ]]; then
+  echo "Expected $expected JSONL manifests, found $actual in $local_results" >&2
+  exit 1
+fi
+
+PYTHONPATH="$repo_root" python - <<PY
+from normalizer.eval_utils import score_results
+
+score_results("$local_results", "$MODEL_ID", families=["public"])
+PY
+
+echo "All Audio8-ASR public HF Jobs completed and scored."

--- a/audio8_asr/submit_jobs.sh
+++ b/audio8_asr/submit_jobs.sh
@@ -4,13 +4,12 @@ set -euo pipefail
 
 # Independent Audio8-ASR HF Jobs submission.
 # Usage:
-#   RESULTS_BUCKET="AutoArk-AI/audio8-asr-open-asr-results" \
 #   HF_TOKEN="hf_..." \
-#   ORG_NAME="AutoArk-AI" \
 #   bash audio8_asr/submit_jobs.sh
+# Override RESULTS_BUCKET and ORG_NAME when running outside the hf-audio namespace.
 
-SPACE="${SPACE:-AutoArk-AI/open-asr-leaderboard-audio8-asr}"
-RESULTS_BUCKET="${RESULTS_BUCKET:?Set RESULTS_BUCKET to a writable Hugging Face bucket}"
+SPACE="${SPACE:-hf-audio/open-asr-leaderboard-audio8-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
 DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
@@ -117,19 +116,15 @@ else
   echo "Jobs page: https://huggingface.co/settings/jobs"
 fi
 
+# Allow the completed Jobs' bucket writes to become visible before syncing.
+sleep 10
+
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 local_results="$repo_root/results/$MODEL_FOLDER"
 mkdir -p "$local_results"
 hf buckets sync \
   "hf://buckets/${RESULTS_BUCKET}/${MODEL_FOLDER}" \
   "$local_results"
-
-actual="$(find "$local_results" -maxdepth 1 -name '*.jsonl' | wc -l)"
-expected="${#DATASET_CONFIGS[@]}"
-if [[ "$actual" -ne "$expected" ]]; then
-  echo "Expected $expected JSONL manifests, found $actual in $local_results" >&2
-  exit 1
-fi
 
 PYTHONPATH="$repo_root" python - <<PY
 from normalizer.eval_utils import score_results


### PR DESCRIPTION
## Description

Adds [`AutoArk-AI/Audio8-ASR-0.1B`](https://huggingface.co/AutoArk-AI/Audio8-ASR-0.1B)
as an independent model family to the Open ASR Leaderboard.

Audio8-ASR-0.1B is a compact autoregressive multilingual ASR model with a
Qwen3-ASR audio encoder and an 8-layer Qwen-style causal language decoder. This
PR adds only `audio8_asr/submit_jobs.sh`; the existing `ark_asr` configuration
is intentionally unchanged.

Evaluation Space:
[`AutoArk-AI/open-asr-leaderboard-audio8-asr`](https://huggingface.co/spaces/AutoArk-AI/open-asr-leaderboard-audio8-asr)

Pinned model revision:
`b812eff124893ecd76a1dcde74ee58db5adab59c`

Run with:

```bash
RESULTS_BUCKET="AutoArk-AI/audio8-asr-open-asr-results" \
HF_TOKEN="hf_..." \
ORG_NAME="AutoArk-AI" \
bash audio8_asr/submit_jobs.sh
```

## Type of change

- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

- [x] H200 WER results, seven-split mean WER, and composite RTFx are published
  in the model repository's
  [`.eval_results/open_asr_leaderboard.yaml`](https://huggingface.co/AutoArk-AI/Audio8-ASR-0.1B/blob/main/.eval_results/open_asr_leaderboard.yaml).
- [x] Dedicated Docker evaluation Space is public and reproducible.
- [x] `trust_remote_code` model loading is pinned to an immutable revision.
- [x] The same decoding hyperparameters are used across all seven datasets.
- [x] The runner saves raw, un-normalized model outputs.
- [x] The runner uses `normalizer/data_utils.py` for Hub loading, filtering, and
  manifest writing.
- [x] Mixed-length batch processing uses tokenizer left padding and explicit
  per-sample mel feature lengths.
- [x] Maximum selected stable H200 batch sizes are used per dataset.
- [x] Warmup and CUDA Event timing are enabled. `torch.compile` remains disabled
  because the pinned remote model code graph-breaks on dynamic KV-cache length.
- [x] End-to-end model parameter count is printed by the runner.
- [x] Raw H200 manifests and summaries are available in
  `hf://buckets/AutoArk-AI/audio8-asr-open-asr-results/AutoArk-AI-Audio8-ASR-0.1B`.

## Evaluation Settings

```text
dtype: bfloat16
attention: eager
decoding: greedy
max_new_tokens: 256
sampling_rate: 16000
max_audio_seconds: 30
prompt: Please transcribe this audio.
CUDA allocator: expandable_segments:True
```

| Split | Rows | Batch | WER | H200 RTFx |
| --- | ---: | ---: | ---: | ---: |
| AMI Cleaned | 7,715 | 1,152 | 10.99 | 396.91 |
| Earnings22 | 2,737 | 1,024 | 12.31 | 654.17 |
| GigaSpeech Cleaned | 18,757 | 1,408 | 8.48 | 641.19 |
| LibriSpeech test.clean | 2,620 | 1,024 | 2.70 | 687.84 |
| LibriSpeech test.other | 2,939 | 1,024 | 6.59 | 610.52 |
| SPGISpeech | 39,341 | 2,048 | 3.73 | 870.32 |
| VoxPopuli Cleaned AA | 628 | 628 | 4.39 | 686.14 |
| **Total / mean** | **74,737** | - | **7.03** | **741.15 composite** |

## Model Metadata

| License | Size (B) | # Languages | Encoder | Decoder |
| --- | ---: | ---: | --- | --- |
| Apache-2.0 | 0.324 | 7 | Qwen3-ASR audio encoder | 8-layer Qwen-style causal LM |

The parameter count is the full end-to-end unique count: `323,990,528`.

## Reproducibility Notes

- The final H200 bundle contains all 74,737 expected rows.
- Audio locators, durations, and normalized references match the independently
  validated local data identity multiset exactly.
- Per-split WER, insertion/deletion/substitution counts, RTFx, model revision,
  parameter count, and decoding settings were recomputed from the synced
  manifests.
- The first batch-1024 attempts exposed CUDA allocator fragmentation during the
  large logits projection. `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`
  resolved it without lowering the selected batch sizes.
- BF16 greedy outputs can differ slightly between singleton and batched decoder
  matrix shapes. The runner guarantees byte-identical valid mel prefixes and
  deterministic repetition of the same batch.
- Empty outputs and 256-token repetition loops are preserved without manual
  repair and remain included in WER.
