### PR TITLE
add hojo asr results

### DIFF
--- a/hojo_asr/run_eval.py
+++ b/hojo_asr/run_eval.py
@@ -14,8 +14,7 @@ wer_metric = evaluate.load("wer")
 def main(args):
     # Load hojo model
     model = HOJO_ASR.load_model(args.model_id, device=args.device)
-
-    print("load hojo ASR model finish")
+    print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
 
     dataset = data_utils.load_data(args)
     dataset = data_utils.prepare_data(dataset)

--- a/hojo_asr/run_eval.py
+++ b/hojo_asr/run_eval.py
@@ -27,7 +27,10 @@ def main(args):
         batch["audio_filepath"] = data_utils.extract_audio_filepaths_from_batch(batch, minibatch_size)
 
         # START TIMING
-        start_time = time.time()
+        torch.cuda.synchronize(device=args.device)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
 
         results = model.run_infer(audios, batch_size=args.batch_size)
 

--- a/hojo_asr/run_eval.py
+++ b/hojo_asr/run_eval.py
@@ -1,0 +1,152 @@
+import json
+import argparse
+import os
+import torch
+from datasets import load_dataset
+from hojo_asr import HOJO_ASR
+import evaluate
+from normalizer import data_utils
+import time
+from tqdm import tqdm
+
+wer_metric = evaluate.load("wer")
+
+def main(args):
+    # Load hojo model
+    model = HOJO_ASR.load_model(args.model_id, device=args.device)
+
+    print("load hojo ASR model finish")
+
+    dataset = data_utils.load_data(args)
+    dataset = data_utils.prepare_data(dataset)
+
+    def benchmark(batch):
+        # Load audio inputs
+        audios = [audio["array"] for audio in batch["audio"]] 
+        batch["audio_length_s"] = [len(audio) / batch["audio"][0]["sampling_rate"] for audio in audios]
+        minibatch_size = len(audios)
+        batch["audio_filepath"] = data_utils.extract_audio_filepaths_from_batch(batch, minibatch_size)
+
+        # START TIMING
+        start_time = time.time()
+
+        results = model.run_infer(audios, batch_size=args.batch_size)
+
+        # Extract text predictions
+        pred_text = [val["text"] for val in results]
+
+        # END TIMING
+        runtime = time.time() - start_time
+
+        # normalize by minibatch size since we want the per-sample time
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+
+        # normalize transcriptions with English normalizer
+        batch["predictions"] = pred_text  # raw; normalization applied at scoring time
+        batch["references"] = batch["original_text"]  # raw; normalization applied at scoring time
+
+        return batch
+
+    dataset = dataset.map(
+        benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
+    )
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+        "audio_filepath": [],
+    }
+    result_iter = iter(dataset)
+    for result in tqdm(result_iter, desc="Samples..."):
+        for key in all_results:
+            all_results[key].append(result[key])
+
+    # Write manifest results (WER and RTFX)
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset_path,
+        args.dataset,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+        audio_filepaths=all_results["audio_filepath"],
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
+    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
+    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    wer = wer_metric.compute(
+        references=norm_refs, predictions=norm_preds
+    )
+    wer = round(100 * wer, 2)
+
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        required=True,
+        help="Model identifier. Should be loadable with qwen_asr",
+    )
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="hf-audio/open-asr-leaderboard",
+        help="Dataset path. By default, it is `hf-audio/open-asr-leaderboard`",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Dataset name. *E.g.* `'librispeech_asr` for the LibriSpeech ASR dataset, or `'common_voice'` for Common Voice. The full list of dataset names "
+        "can be found at `https://huggingface.co/datasets/hf-audio/open-asr-leaderboard`",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Split of the dataset. *E.g.* `'validation`' for the dev split, or `'test'` for the test split.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=-1,
+        help="The device to run the pipeline on. -1 for CPU (default), 0 for the first GPU and so on.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="Number of samples to go through each streamed batch.",
+    )
+    parser.add_argument(
+        "--max_eval_samples",
+        type=int,
+        default=None,
+        help="Number of samples to be evaluated. Put a lower number e.g. 64 for testing this script.",
+    )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Stream the dataset lazily over the network instead of downloading it in full before the evaluation. Off by default for reproducible benchmark timings.",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=256,
+        help="Maximum number of tokens to generate.",
+    )
+
+    args = parser.parse_args()
+    parser.set_defaults(streaming=False)
+
+    main(args)

--- a/hojo_asr/run_eval.py
+++ b/hojo_asr/run_eval.py
@@ -38,7 +38,9 @@ def main(args):
         pred_text = [val["text"] for val in results]
 
         # END TIMING
-        runtime = time.time() - start_time
+        end_event.record()
+        torch.cuda.synchronize(device=args.device)
+        runtime = start_event.elapsed_time(end_event) / 1000.0
 
         # normalize by minibatch size since we want the per-sample time
         batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]

--- a/hojo_asr/submit_jobs.sh
+++ b/hojo_asr/submit_jobs.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Local script to submit HF Jobs for Qwen ASR evaluation.
+# Usage: HF_TOKEN=hf_... bash submit_jobs.sh
+
+# ── Configuration ────────────────────────────────────────────────────────────
+SPACE="${SPACE:-HojoAI/open-asr-leaderboard-hojo-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-HojoAI/openasr_eval}"
+DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+FLAVOR="${FLAVOR:-h200}"
+ORG_NAME="${ORG_NAME:-}"
+MAX_NEW_TOKENS=256  # matches the official qwen-asr package default
+
+# ── Models ────────────────────────────────────────────────────────────────────
+MODEL_CONFIGS=(
+    "HojoAI/Hojo-ASR-V1"
+)
+
+# ── Datasets: "name split batch_size" ────────────────────────────────────────
+DATASET_CONFIGS=(
+    "ami_cleaned test 32"
+    "gigaspeech_cleaned test 32"
+    "voxpopuli_cleaned_aa test 32"
+    "earnings22 test 32"
+    "librispeech test.clean 32"
+    "librispeech test.other 32"
+    "spgispeech test 32"
+)
+
+# ── Submit one job per model/dataset combination ─────────────────────────────
+for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
+    MODEL_FOLDER="${MODEL_ID//\//-}"
+
+    echo "████████████████████████████████████████████████████████████████████████████████"
+    echo "  Evaluating: ${MODEL_ID}"
+    echo "████████████████████████████████████████████████████████████████████████████████"
+
+    for cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+
+        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+
+        NAMESPACE_ARG=""
+        [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
+
+        hf jobs run \
+            --flavor "$FLAVOR" \
+            --timeout 8h \
+            --env HF_TOKEN="$HF_TOKEN" \
+            --env HF_AUDIO_DECODER_BACKEND="soundfile" \
+            ${NAMESPACE_ARG} \
+            --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
+            "hf.co/spaces/${SPACE}" \
+            bash -c "
+                PYTHONPATH=/app python run_eval.py \
+                    --model_id=${MODEL_ID} \
+                    --dataset_path=${DATASET_PATH} \
+                    --dataset=${DATASET} \
+                    --split=${SPLIT} \
+                    --device=0 \
+                    --batch_size=${BATCH_SIZE} \
+                    --max_eval_samples=-1 \
+                    --max_new_tokens=${MAX_NEW_TOKENS} &&
+                mkdir -p /results/${MODEL_FOLDER} &&
+                cp results/*.jsonl /results/${MODEL_FOLDER}/
+            " > /dev/null 2>&1 &
+    done
+    if [ -n "$ORG_NAME" ]; then
+        echo "For live status see: https://huggingface.co/organizations/${ORG_NAME}/settings/jobs"
+    else
+        echo "For live status see: https://huggingface.co/settings/jobs"
+    fi
+
+    wait
+    echo "All jobs finished for ${MODEL_ID}."
+    sleep 10  # allow time for the last results to be flushed to the bucket
+
+    mkdir -p "./results/${MODEL_FOLDER}"
+    hf buckets sync \
+        "hf://buckets/${RESULTS_BUCKET}/${MODEL_FOLDER}" \
+        "./results/${MODEL_FOLDER}" > /dev/null 2>&1
+
+    EXPECTED=${#DATASET_CONFIGS[@]}
+    ACTUAL=$(find "./results/${MODEL_FOLDER}" -name "*.jsonl" | wc -l)
+    if [[ "$ACTUAL" -lt "$EXPECTED" ]]; then
+        echo "WARNING: expected ${EXPECTED} result files but only found ${ACTUAL}. Some jobs may not have finished yet."
+    else
+        echo "All ${ACTUAL} result files present."
+    fi
+
+    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
+    PYTHONPATH="${REPO_ROOT}" python -c "
+from normalizer.eval_utils import score_results
+score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')
+"
+
+done

--- a/hojo_asr/submit_jobs.sh
+++ b/hojo_asr/submit_jobs.sh
@@ -3,8 +3,8 @@
 # Usage: HF_TOKEN=hf_... bash submit_jobs.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
-SPACE="${SPACE:-HojoAI/open-asr-leaderboard-hojo-asr}"
-RESULTS_BUCKET="${RESULTS_BUCKET:-HojoAI/openasr_eval}"
+SPACE="${SPACE:-hf-audio/open-asr-leaderboard-hojo-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
 DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"


### PR DESCRIPTION
## Description

Add Hojo-ASR model , a high-performance conversational speech recognition model powered by the Qwen3 LLM decoder. It adopts the classic Encoder-Adapter-LLM framework, fully leveraging acoustic fine-grained features and strong LLM semantic capabilities.

Model repo result file:
`https://huggingface.co/HojoAI/Hojo-ASR-V1/blob/main/.eval_results/open_asr_leaderboard.yaml`

Raw JSONL manifests for maintainer verification:
`https://huggingface.co/buckets/HojoAI/openasr_eval/tree/HojoAI-Hojo-ASR-V1`

HF Jobs Space for reproduction:
`https://huggingface.co/spaces/HojoAI/open-asr-leaderboard-hojo-asr`

Results:

|Split | WER | RTFx|
|:--------|:--------|:---------|
| ami_cleaned_test | 7.53 | 57.45 |
| earnings22_test | 8.15 | 55.62 |
| gigaspeech_cleaned_test | 6.14 | 70.35 |
| librispeech_test.clean | 1.30 | 63.33 |
| librispeech_test.other | 3.24 | 59.34 |
| spgispeech_test | 1.74 | 90.61|
| voxpopuli_cleaned_aa_test | 3.11 | 60.73 |

Composite Results:

HojoAI/Hojo-ASR-V1: WER = 4.46 %
HojoAI/Hojo-ASR-V1: RTFX = 78.77

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

Results are reported in the model repo:
`https://huggingface.co/HojoAI/Hojo-ASR-V1/blob/main/.eval_results/open_asr_leaderboard.yaml`

### HF Jobs evaluation (recommended)

Using [HF Jobs](https://huggingface.co/docs/hub/en/jobs-overview) makes it straightforward for maintainers to reproduce and verify your results. There are configurations for multiple model libraries available [here](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations).

- [x] (If a custom configuration is needed) duplicate one of the Space above (click the ⋮ menu → **Duplicate this Space**) to create your own copy, e.g. `your-username/open-asr-leaderboard-mymodel`.
    - [x] Modify the `Dockerfile` to install your model's dependencies, e.g. installing from a specific version/fork of Transformers.
    - [x] Adapt `run_eval.py` for your model — use the [Transformers one](https://huggingface.co/spaces/hf-audio/open-asr-leaderboard-transformers/blob/main/run_eval.py) as a starting point. There is no need to modify/update the normalizer files, as the `run_eval.py` script should save the raw (un-normalized) transcripts and model outptus, and the normalizer from the repo is locally score the model outputs.
    - [ ] For models that use `trust_remote_code=True`, please default to a `revision` tag and specify it in your bash script. 
- [x] In this repo, create a folder for your model library and a `submit_jobs.sh` script (use any existing one in this repo as a template) pointing to your Space and a results bucket.

####  Key guidelines
- [x] Use the **same decoding hyper-parameters** across all datasets for a given model.
- [x] (If writing a new) `run_eval.py`, it must support **batch processing** and use `normalizer/data_utils.py` for data loading, normalization, and manifest writing.
- [ ] Use the **maximum possible batch size** (can differ per dataset) on an H200 GPU.
- [ ] Use `torch.compile` and/or relevant optimizations including warmup to maximize RTFx.
- [ ] Even if you're not using HF Jobs, prepare an HF space like the [existing models](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations), such that the maintainers can reproduce your results on HF Jobs.
- [x] Please report your results on the relevant public sets, as well as the RTFx.
- [ ] Please provide the following model metadata (see [here](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-results/blob/main/english_short_latest.csv) for existing models).

For LLM-based models, be sure to count the **total number** of parameters. You can get the exact number by adding the following line in your `run_eval.py` script:
```python
print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
```

### My model is not in Transformers (yet 🙃)

- [x] Duplicate an [existing Space](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations) that is closest to your model's framework, then modify the Dockerfile to install the required dependencies.
- [x] Adapt run_eval.py for your model's inference API (supports batch processing and relevant optimizations).
- [x] Create a submit_jobs_<your_model>.sh script pointing to your new Space, and include it in your PR.


## New Dataset Checklist
- [ ] The dataset is hosted on the HF Hub with **just** the test set.
- [ ] Create a new Bash script with one of the existing models. For example, adapting the `submit_jobs.sh` script for Parakeet or Whisper to add a line for your dataset. 

## Related issues
Closes #