### PR TITLE
Add Spirelight Transcribe API provider

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -61,5 +61,6 @@ from . import (
     revai_provider,
     smallest_provider,
     speechmatics_provider,
+    spirelight_transcribe_provider,
     zoom_provider,
 )

--- a/api/providers/spirelight_transcribe_provider.py
+++ b/api/providers/spirelight_transcribe_provider.py
@@ -1,0 +1,52 @@
+"""Public API provider for the Open ASR Leaderboard, targeting Spirelight's
+live production TSP API. Submits audio via /v1/transcribe, polls
+/v1/job/{job_id} for completion, and returns the transcript text.
+"""
+import os
+import time
+import requests
+
+from . import register, APIProvider, PermanentError
+
+API_BASE = os.environ.get("TSP_API_BASE", "http://transcribe.spirelight.net:29371")
+API_KEY = os.environ.get("TSP_API_KEY", "")
+POLL_INTERVAL_SEC = 2
+POLL_TIMEOUT_SEC = 3600
+
+
+@register("tsp")
+class TSPProvider(APIProvider):
+    def transcribe(self, model_variant, audio_file_path, sample, use_url=False,
+                   language="en", prompt=None):
+        if use_url:
+            raise PermanentError("use_url mode not supported")
+
+        with open(audio_file_path, "rb") as f:
+            resp = requests.post(
+                f"{API_BASE}/v1/transcribe",
+                headers={"x-api-key": API_KEY},
+                files={"audio": f},
+                data={"language": language},
+                timeout=120,
+            )
+        if resp.status_code != 200:
+            raise PermanentError(f"Submit failed: {resp.status_code} {resp.text[:300]}")
+        job_id = resp.json()["job_id"]
+
+        start = time.time()
+        while time.time() - start < POLL_TIMEOUT_SEC:
+            status_resp = requests.get(
+                f"{API_BASE}/v1/job/{job_id}",
+                headers={"x-api-key": API_KEY},
+                timeout=30,
+            )
+            if status_resp.status_code != 200:
+                raise PermanentError(f"Status check failed: {status_resp.status_code} {status_resp.text[:300]}")
+            data = status_resp.json()
+            if data["status"] == "completed":
+                return data.get("text", "")
+            if data["status"] == "failed":
+                raise PermanentError(f"Job failed: {data.get('error')}")
+            time.sleep(POLL_INTERVAL_SEC)
+
+        raise PermanentError(f"Timed out waiting for job {job_id}")

--- a/api/providers/spirelight_transcribe_provider.py
+++ b/api/providers/spirelight_transcribe_provider.py
@@ -14,7 +14,7 @@ POLL_INTERVAL_SEC = 2
 POLL_TIMEOUT_SEC = 3600
 
 
-@register("tsp")
+@register("spirelight")
 class TSPProvider(APIProvider):
     def transcribe(self, model_variant, audio_file_path, sample, use_url=False,
                    language="en", prompt=None):

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -28,6 +28,7 @@ MODEL_CONFIGS=(
     # "microsoft/azure-speech-05-2026  4"
     # "modulate/vfast                25"
     # "gladia/solaria-3             20"
+    # "spirelight/transcribe        16"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 
@@ -90,6 +91,7 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             -e SMALLESTAI_API_KEY="${SMALLESTAI_API_KEY:-}" \
             -e RESON8_API_KEY="${RESON8_API_KEY:-}" \
             -e AZURE_API_KEY="${AZURE_API_KEY:-}" \
+            -e TSP_API_KEY="${TSP_API_KEY:-}" \
             -v "${RUNDIR}/results:/app/results" \
             -v "${REPO_ROOT}/../normalizer:/app/normalizer" \
             -v "${HF_CACHE_DIR}:/hf_cache" \


### PR DESCRIPTION
## Description

Add Spirelight Transcribe as an API-based model submission.

## Type of change
- [x] New model

## API models

- [x] Contacted the maintainers to provide an API key. Emailed sanchit@huggingface.com and vf@hf.com
- [x] Added `spirelight_transcribe_provider.py` here: https://github.com/PekkaL84/open_asr_leaderboard/blob/add-spirelight-transcribe-provider/api/providers/spirelight_transcribe_provider.py
- [x] Imported it in `api/providers/__init__.py`
- [x] In `api/run_api.sh` added:
    - a line in `MODEL_CONFIGS`: `spirelight/transcribe   16`
    - a line passing the API key to `docker run`: `-e TSP_API_KEY="${TSP_API_KEY:-}"`
- [x] Documentation link: https://spirelight.ai/stt
- [x] Information:
    - Link to API documentation: https://spirelight.ai/stt
    - Languages supported: 1 (English)

## Results (official kaldialign method, merge_compounds=True)

| Dataset | WER |
|---|---:|
| AMI-Cleaned | 7.0807% |
| Earnings22 | 7.8253% |
| GigaSpeech-Cleaned | 7.0398% |
| LibriSpeech-Clean | 0.9226% |
| LibriSpeech-Other | 2.0363% |
| SPGISpeech | 2.8705% |
| VoxPopuli-Cleaned | 2.5364% |
| **Average** | **4.3302%** |

## Model metadata

| License | Size (B) | # Languages | Encoder | Decoder |
|---|---|---|---|---|
| Proprietary | | 1 | | LLM |

## Related issues
Closes #
