### PR TITLE
Add URGENT 2024

### DIFF
--- a/transformers/run_whisper.sh
+++ b/transformers/run_whisper.sh
@@ -83,6 +83,24 @@ do
         --batch_size=${BATCH_SIZE} \
         --max_eval_samples=-1
 
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="cifkao/open-asr-leaderboard" \
+        --dataset="urgent2024_nonblind" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
+    python run_eval.py \
+        --model_id=${MODEL_ID} \
+        --dataset_path="cifkao/open-asr-leaderboard" \
+        --dataset="urgent2024_nonblind_clean" \
+        --split="test" \
+        --device=0 \
+        --batch_size=${BATCH_SIZE} \
+        --max_eval_samples=-1
+
     # Evaluate results
     RUNDIR=`pwd` && \
     cd ../normalizer && \


### PR DESCRIPTION
Cc @sw005320 @faroit

## Description

Adding the non-blind test set from the [2024 Urgent Challenge](https://arxiv.org/abs/2406.04660) [[Hugging Face](https://huggingface.co/datasets/urgent-challenge/urgent2024_official)]. English, ~1000 utterances (~2h), two subsets:

* `urgent2024_nonblind` – degraded (noisy) speech
* `urgent2024_nonblind_clean` – the paired clean references

URGENT is the most impactful speech enhancement challenge. The data is made challenging by additive noise, reverberation, bandwidth limitation, and clipping. URGENT includes ASR as one of the downstream tasks but its aim is not to benchmark SOTA ASR models (it uses OWSM v3.1 only); this is what we aim to enable by including this data in Open ASR Leaderboard. For 8 out of 10 Whisper models, it is more challenging than any existing dataset on the benchmark (results below). Moreover, the paired clean dataset allows measuring the gap (+7 to +25 WER) and separating models by noise-robustness. It should also allow measuring the impact of speech enhancement on ASR performance.

I opened [PR #12](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard/discussions/12) in `hf-audio/open-asr-leaderboard` on Hugging Face to add the data (a straightforward conversion to the leaderboard format, [script here](https://gist.github.com/cifkao/85a164c97f5f35a4da82985d36a041a1)); it's also added to [`cifkao/open-asr-leaderboard`](https://huggingface.co/datasets/cifkao/open-asr-leaderboard).

The data in the original format is in [`urgent-challenge/urgent2024_official`](https://huggingface.co/datasets/urgent-challenge/urgent2024_official). It is simulated from these corpora (per [Zhang et al., 2025](https://www.isca-archive.org/interspeech_2025/zhang25j_interspeech.pdf)):

| Corpus | Role | Subset | License |
| --- | --- | --- | --- |
| Common Voice 11.0 (English, test) | speech | clean + noisy | CC0 |
| LibriTTS (test) | speech | clean + noisy | CC BY 4.0 |
| VCTK (test) | speech | clean + noisy | ODC-BY |
| CC-licensed YouTube audio | speech | clean + noisy | Creative Commons (per video) |
| WHAM! (test) | noise | noisy only | CC BY-NC 4.0 |
| DEMAND | noise | noisy only | CC BY-SA 3.0 |
| TUT Urban Acoustic Scenes 2018 (eval) | noise | noisy only | Non-commercial (research only) |
| SLR28 real RIRs | RIR | noisy only | Apache-2.0 |
| MYRiAD v2 | RIR | noisy only | CC BY 4.0 |

**Licensing summary:** `urgent2024_nonblind_clean` draws only on CC0 / CC BY 4.0 / ODC-BY / CC sources (permissive, attribution). `urgent2024_nonblind` additionally mixes in WHAM! (CC BY-NC 4.0) and TUT Urban Acoustic Scenes (non-commercial), making the noisy subset **research / non-commercial**.

### Whisper results

| model | urgent2024 nonblind | urgent2024 nonblind clean | librispeech clean | librispeech other | ami | earnings22 | gigaspeech | spgispeech | tedlium | voxpopuli |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| openai/whisper-large-v3 | 13.8 | 6.4 | 2.0 | 3.9 | 16.0 | 11.3 | 10.1 | 3.0 | 3.8 | 9.6 |
| distil/whisper-distil-large-v3 | 14.1 | 6.5 | 2.5 | 5.2 | 15.1 | 11.8 | 10.1 | 3.3 | 3.9 | 8.2 |
| distil/whisper-distil-large-v2 | 15.8 | 7.0 | 3.0 | 6.8 | 14.6 | 12.1 | 10.3 | 3.3 | 4.7 | 8.3 |
| distil/whisper-distil-medium.en | 17.3 | 8.5 | 3.7 | 8.4 | 16.1 | 13.1 | 11.3 | 3.8 | 4.9 | 9.0 |
| openai/whisper-large | 17.3 | 9.5 | 2.7 | 5.5 | 16.8 | 12.1 | 10.8 | 3.2 | 3.9 | 7.8 |
| openai/whisper-medium.en | 17.6 | 8.6 | 2.9 | 5.8 | 16.4 | 12.5 | 10.9 | 3.4 | 4.1 | 8.0 |
| openai/whisper-large-v2 | 21.5 | 12.8 | 2.9 | 5.2 | 17.2 | 12.0 | 10.7 | 3.9 | 3.9 | 7.5 |
| openai/whisper-small.en | 22.1 | 12.2 | 3.0 | 7.2 | 17.9 | 12.9 | 11.5 | 3.6 | 4.0 | 8.5 |
| openai/whisper-base.en | 34.2 | 10.1 | 4.3 | 10.4 | 21.1 | 15.1 | 12.7 | 4.3 | 4.9 | 9.8 |
| openai/whisper-tiny.en | 38.3 | 12.9 | 5.6 | 14.6 | 24.7 | 18.7 | 14.1 | 5.9 | 5.9 | 11.5 |
| mean | 21.2 | 9.5 | 3.3 | 7.3 | 17.6 | 13.2 | 11.3 | 3.8 | 4.4 | 8.8 |

## Type of change

* [ ] New model
* [x] New dataset
* [ ] Bug fix
* [ ] New feature
* [ ] Other

## New Dataset Checklist

* [x] The dataset is hosted on the HF Hub with just the test set.
* [x] Create a new Bash script with one of the existing models: adapted `transformers/run_whisper.sh`.