### PR TITLE
Add MOSS-Transcribe-Diarize multilingual evaluation

### DIFF
--- a/moss-transcribe-diarize/run_eval_ml.py
+++ b/moss-transcribe-diarize/run_eval_ml.py
@@ -1,0 +1,45 @@
+"""Multilingual entry point for the MOSS Open ASR evaluator.
+
+The inference implementation stays in ``run_eval.py`` so English and
+multilingual evaluations cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from run_eval import main as run_eval_main
+
+
+def main(args: argparse.Namespace) -> int:
+    """Adapt multilingual dataset arguments to the shared evaluator."""
+    config_language = args.config_name.rsplit("_", 1)[-1]
+    if args.language is not None and args.language != config_language:
+        raise ValueError(
+            f"Language {args.language!r} does not match config {args.config_name!r}"
+        )
+
+    args.dataset_path = args.dataset
+    args.dataset = args.config_name
+    return run_eval_main(args)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model_id", required=True)
+    parser.add_argument(
+        "--model_revision",
+        default="e5118b411bf5a77d7a90c4941066bec93c967312",
+    )
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--config_name", required=True)
+    parser.add_argument("--language", default=None)
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--batch_size", type=int, default=256)
+    parser.add_argument("--max_new_tokens", type=int, default=2048)
+    parser.add_argument("--batch_max_new_tokens", type=int, default=512)
+    parser.add_argument("--max_eval_samples", type=int, default=None)
+    parser.add_argument("--streaming", action="store_true")
+    parser.add_argument("--warmup_steps", type=int, default=1)
+    raise SystemExit(main(parser.parse_args()))

--- a/moss-transcribe-diarize/submit_jobs_ml.sh
+++ b/moss-transcribe-diarize/submit_jobs_ml.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPACE="${SPACE:-hf-audio/open-asr-leaderboard-moss-transcribe-diarize}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_multilingual}"
+DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard-multilingual-datasets}"
+FLAVOR="${FLAVOR:-h200}"
+ORG_NAME="${ORG_NAME:-}"
+MODEL_ID="${MODEL_ID:-OpenMOSS-Team/MOSS-Transcribe-Diarize}"
+MODEL_REVISION="${MODEL_REVISION:-e5118b411bf5a77d7a90c4941066bec93c967312}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-2048}"
+BATCH_MAX_NEW_TOKENS="${BATCH_MAX_NEW_TOKENS:-512}"
+MAX_EVAL_SAMPLES="${MAX_EVAL_SAMPLES:--1}"
+WARMUP_STEPS="${WARMUP_STEPS:-1}"
+BATCH_SIZE="${BATCH_SIZE:-256}"
+JOB_TIMEOUT="${JOB_TIMEOUT:-8h}"
+
+DATASET_CONFIGS=(
+    "fleurs de"
+    "fleurs fr"
+    "fleurs it"
+    "fleurs es"
+    "fleurs pt"
+    "mcv de"
+    "mcv es"
+    "mcv fr"
+    "mcv it"
+    "mls es"
+    "mls fr"
+    "mls it"
+    "mls pt"
+)
+
+# Optional smoke-test override: DATASETS="fleurs:pt mcv:de" bash ...
+if [[ -n "${DATASETS:-}" ]]; then
+    DATASET_CONFIGS=()
+    for pair in ${DATASETS}; do
+        DATASET_CONFIGS+=("${pair/:/ }")
+    done
+fi
+
+if [[ -z "${HF_TOKEN:-}" ]]; then
+    echo "HF_TOKEN is required" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MODEL_FOLDER="${MODEL_ID//\//-}"
+
+# Use the local scripts while iterating; set USE_LOCAL_SCRIPT=0 to use the
+# versions committed to the evaluator Space.
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "${USE_LOCAL_SCRIPT}" == "1" ]]; then
+    RUN_EVAL_B64="$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")"
+    RUN_EVAL_ML_B64="$(base64 -w0 "${SCRIPT_DIR}/run_eval_ml.py")"
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py && echo '${RUN_EVAL_ML_B64}' | base64 -d > /app/run_eval_ml.py &&"
+fi
+
+# Keep scoring identical to the local repository while iterating.
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "${USE_LOCAL_NORMALIZER}" == "1" ]]; then
+    NORMALIZER_B64="$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)"
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
+
+NAMESPACE_ARGS=()
+if [[ -n "${ORG_NAME}" ]]; then
+    NAMESPACE_ARGS=(--namespace "${ORG_NAME}")
+fi
+
+pids=()
+for config in "${DATASET_CONFIGS[@]}"; do
+    read -r dataset language <<< "${config}"
+    config_name="${dataset}_${language}"
+    echo "Submitting model=${MODEL_ID} config=${config_name} batch_size=${BATCH_SIZE}"
+
+    (
+        hf jobs run \
+            --flavor "${FLAVOR}" \
+            --timeout "${JOB_TIMEOUT}" \
+            --secrets HF_TOKEN \
+            --env HF_AUDIO_DECODER_BACKEND=soundfile \
+            "${NAMESPACE_ARGS[@]}" \
+            --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
+            "hf.co/spaces/${SPACE}" \
+            bash -c "
+                set -euo pipefail
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
+                PYTHONPATH=/app python run_eval_ml.py \
+                    --model_id='${MODEL_ID}' \
+                    --model_revision='${MODEL_REVISION}' \
+                    --dataset='${DATASET_PATH}' \
+                    --config_name='${config_name}' \
+                    --language='${language}' \
+                    --split='test' \
+                    --device=0 \
+                    --batch_size='${BATCH_SIZE}' \
+                    --batch_max_new_tokens='${BATCH_MAX_NEW_TOKENS}' \
+                    --max_new_tokens='${MAX_NEW_TOKENS}' \
+                    --max_eval_samples='${MAX_EVAL_SAMPLES}' \
+                    --warmup_steps='${WARMUP_STEPS}'
+                mkdir -p '/results/${MODEL_FOLDER}'
+                cp results/*.jsonl '/results/${MODEL_FOLDER}/'
+            "
+    ) &
+    pids+=("$!")
+done
+
+failed=0
+for pid in "${pids[@]}"; do
+    if ! wait "${pid}"; then
+        failed=1
+    fi
+done
+if [[ "${failed}" -ne 0 ]]; then
+    echo "One or more HF Jobs failed" >&2
+    exit 1
+fi
+
+sleep 10
+
+local_results="${REPO_ROOT}/results/${MODEL_FOLDER}"
+mkdir -p "${local_results}"
+hf buckets sync \
+    "hf://buckets/${RESULTS_BUCKET}/${MODEL_FOLDER}" \
+    "${local_results}"
+
+missing=0
+for config in "${DATASET_CONFIGS[@]}"; do
+    read -r dataset language <<< "${config}"
+    config_name="${dataset}_${language}"
+    expected="MODEL_${MODEL_FOLDER}_DATASET_${DATASET_PATH//\//-}_${config_name}_test.jsonl"
+    if [[ ! -f "${local_results}/${expected}" ]]; then
+        echo "Missing result: ${expected}" >&2
+        missing=1
+    fi
+done
+if [[ "${missing}" -ne 0 ]]; then
+    exit 1
+fi
+
+languages=()
+for config in "${DATASET_CONFIGS[@]}"; do
+    read -r _ language <<< "${config}"
+    if [[ ! " ${languages[*]} " == *" ${language} "* ]]; then
+        languages+=("${language}")
+    fi
+done
+
+for language in "${languages[@]}"; do
+    PYTHONPATH="${REPO_ROOT}" python -c "
+from normalizer.eval_utils import score_results
+score_results('${local_results}', '${MODEL_ID}', multilingual=True, language='${language}', families=['ml_${language}'], csv_only=True)
+"
+done
+
+echo "All MOSS-Transcribe-Diarize multilingual HF Jobs completed and scored."


### PR DESCRIPTION
## Description

Extends the existing MOSS-Transcribe-Diarize leaderboard integration with multilingual evaluation support.

This PR adds:

- `run_eval_ml.py`, a thin multilingual wrapper around the existing MOSS evaluator.
- `submit_jobs_ml.sh`, following the repository’s HF Jobs pattern.
- Reuses the existing English MOSS evaluator and model integration.
- Evaluation support for:
  - FLEURS: German, French, Italian, Spanish, Portuguese
  - MCV: German, Spanish, French, Italian
  - MLS: Spanish, French, Italian, Portuguese
- A fixed model revision for reproducibility.
- Language/config validation.
- Official multilingual normalizer and scorer integration.

The existing evaluator Space is reused:

https://huggingface.co/spaces/hf-audio/open-asr-leaderboard-moss-transcribe-diarize

## Type of change

- [ ] New model
- [ ] New dataset
- [ ] Bug fix
- [x] New feature
- [ ] Other

## Reproduction

From the repository root:

```bash
export HF_TOKEN=...

# Small smoke evaluation
DATASETS="fleurs:pt" \
MAX_EVAL_SAMPLES=16 \
BATCH_SIZE=16 \
bash moss-transcribe-diarize/submit_jobs_ml.sh

# Full multilingual evaluation
bash moss-transcribe-diarize/submit_jobs_ml.sh
```

The script submits one HF Job per dataset/language configuration, stores manifests in the multilingual results bucket, downloads the results locally, and scores each language using the repository normalizer.

## Validation

Local validation was performed with an AMD Radeon RX 7700 XT using PyTorch 2.11.0+rocm7.1:

- FLEURS smoke tests passed for all five languages.
- MCV German smoke test passed using streaming.
- MLS Portuguese smoke test passed using streaming.
- Manifest generation passed.
- Multilingual scoring passed.
- `bash -n` passed for the submission script.
- Python compilation passed for the evaluator scripts.

The official HF Jobs smoke test and full benchmark results are pending.

I do not currently have HF Jobs credits to run the full H200 evaluation. The local AMD/ROCm smoke tests passed for FLEURS, MCV, and MLS. Maintainers can run or help validate the official HF Jobs benchmark if required.

## Multilingual Evaluation Checklist

- [x] The existing MOSS HF evaluator Space is reused.
- [x] The existing MOSS inference implementation is reused.
- [x] The model uses `trust_remote_code=True` with a pinned revision.
- [x] A multilingual `run_eval_ml.py` entry point was added.
- [x] A multilingual `submit_jobs_ml.sh` script was added.
- [ ] Official WER and RTFx results have been added after the HF Jobs evaluation.

### Key guidelines

- [x] The same decoding hyperparameters are used across all datasets.
- [x] The evaluator supports batch processing.
- [ ] Maximum H200 batch size has been calibrated with a full HF Jobs run.
- [ ] `torch.compile` or additional compilation optimizations are enabled.
- [x] An HF Space is available for reproducible evaluation.
- [ ] Results for all public sets have been reported.
- [x] The evaluator reports the total number of model parameters.

### Model metadata

| License | Size (B) | # Languages | Encoder | Decoder | Training data disclosure |
|---|---:|---:|---|---|---|
| Apache-2.0 | 0.91B | 50+ | Whisper-Medium | Qwen3-0.6B | Not specified in the [model card](https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize) |

The model card is available at:

https://huggingface.co/OpenMOSS-Team/MOSS-Transcribe-Diarize

- [x] The model license appears on the model card.

## Related issues

Closes #
