### PR TITLE
Add Hojo-ASR-Mul-V1 multilingual evaluation

### DIFF
--- a/hojo_asr/run_eval_ml.py
+++ b/hojo_asr/run_eval_ml.py
@@ -1,0 +1,190 @@
+import argparse
+import os
+import torch
+from hojo_asr import HOJO_ASR
+import evaluate
+from normalizer import data_utils
+from normalizer.eval_utils import normalize_compound_pairs
+import time
+from tqdm import tqdm
+from datasets import load_dataset, Audio
+
+wer_metric = evaluate.load("wer")
+
+
+def main(args):
+    CONFIG_NAME = args.config_name
+    SPLIT_NAME = args.split
+    
+    # Extract language from config_name if not provided
+    if args.language:
+        LANGUAGE = args.language
+    else:
+        try:
+            LANGUAGE = CONFIG_NAME.split("_", 1)[1]
+        except IndexError:
+            LANGUAGE = "en"
+
+    model = HOJO_ASR.load_model(args.model_id, device=args.device)
+    print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
+
+    def benchmark(batch):
+        # Load audio inputs
+        audios = [audio["array"] for audio in batch["audio"]]
+        batch["audio_length_s"] = [len(audio) / batch["audio"][0]["sampling_rate"] for audio in audios]
+        minibatch_size = len(audios)
+
+        # START TIMING
+        torch.cuda.synchronize(device=args.device)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+
+        results = model.run_infer(audios, batch_size=args.batch_size)
+
+        # Extract text predictions
+        pred_text = [val["text"] for val in results]
+
+        # END TIMING
+        end_event.record()
+        torch.cuda.synchronize(device=args.device)
+        runtime = start_event.elapsed_time(end_event) / 1000.0
+
+        # normalize by minibatch size since we want the per-sample time
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+
+        # Get references from the dataset
+        batch["references"] = batch["text"]
+
+        # normalize transcriptions with English normalizer
+        batch["predictions"] = pred_text  # raw; normalization applied at scoring time
+        batch["references"] = batch["text"]  # raw; normalization applied at scoring time
+
+        return batch
+
+    dataset = load_dataset(
+        args.dataset,
+        CONFIG_NAME,
+        split=SPLIT_NAME,
+        streaming=args.streaming,
+        token=True,
+    )
+
+    # Resample to 16kHz
+    dataset = dataset.cast_column("audio", Audio(sampling_rate=16000))
+
+    dataset = dataset.map(
+        benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
+    )
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+    }
+
+    result_iter = iter(dataset)
+    for result in tqdm(result_iter, desc="Samples..."):
+        for key in all_results:
+            all_results[key].append(result[key])
+
+    # Filter empty references (consistent with English pipeline)
+    filtered = [
+        (ref, pred, dur, time_s)
+        for ref, pred, dur, time_s in zip(
+            all_results["references"], all_results["predictions"],
+            all_results["audio_length_s"], all_results["transcription_time_s"]
+        )
+        if data_utils.is_target_text_in_range(ref)
+    ]
+    if filtered:
+        all_results["references"], all_results["predictions"], all_results["audio_length_s"], all_results["transcription_time_s"] = zip(*filtered)
+        all_results = {k: list(v) for k, v in all_results.items()}
+
+    # Write manifest results (WER and RTFX)
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset,
+        CONFIG_NAME,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
+    norm_refs = [data_utils.ml_normalizer(r, lang=LANGUAGE) for r in all_results["references"]]
+    norm_preds = [data_utils.ml_normalizer(p, lang=LANGUAGE) for p in all_results["predictions"]]
+    wer_refs, wer_preds = normalize_compound_pairs(norm_refs, norm_preds)
+    wer = wer_metric.compute(references=wer_refs, predictions=wer_preds)
+    wer = round(100 * wer, 2)
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--model_id",
+        type=str,
+        required=True,
+        help="Model identifier. Should be loadable with qwen_asr",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help=(
+            "Hub id (e.g. 'nithinraok/asr-leaderboard-datasets') or local data root "
+            "containing <corpus>/<lang>_test.parquet "
+            "(e.g. '.../asr-leaderboard-datasets/data')."
+        ),
+    )
+    parser.add_argument(
+        "--config_name",
+        type=str,
+        required=True,
+        help="Config name for the dataset. *E.g.* `'fleurs_en'` for English FLEURS.",
+    )
+    parser.add_argument(
+        "--language",
+        type=str,
+        default=None,
+        help="Language code (e.g., 'de'). If not provided, extracted from config_name.",
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="test",
+        help="Split of the dataset. *E.g.* `'test'` for the test split.",
+    )
+    parser.add_argument(
+        "--device",
+        type=int,
+        default=-1,
+        help="The device to run the pipeline on. -1 for CPU (default), 0 for the first GPU and so on.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=16,
+        help="Number of samples to go through each batch.",
+    )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Stream the dataset lazily over the network instead of downloading it in full before the evaluation. Off by default for reproducible benchmark timings.",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=256,
+        help="Maximum number of tokens to generate.",
+    )
+    parser.set_defaults(streaming=False)
+    args = parser.parse_args()
+
+    main(args)

--- a/hojo_asr/submit_jobs_ml.sh
+++ b/hojo_asr/submit_jobs_ml.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# Local script to submit HF Jobs for multilingual Hojo ASR evaluation.
+# Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
+# This script is NOT pushed to the HF Space — it runs on your local machine.
+# Usage: HF_TOKEN=hf_... bash submit_ml_jobs.sh
+
+# ── Configuration ────────────────────────────────────────────────────────────
+SPACE="${SPACE:-HojoAI/open-asr-leaderboard-hojo-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-HojoAI/openasr_eval}"
+DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard-multilingual-datasets}"
+FLAVOR="${FLAVOR:-h200}"
+ORG_NAME="${ORG_NAME:-}"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval_ml.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    LOCAL_SCRIPT_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval_ml.py")
+    LOCAL_SCRIPT_INJECT="echo '${LOCAL_SCRIPT_B64}' | base64 -d > /app/run_eval_ml.py &&"
+fi
+
+# ── Models: "model_id batch_size" ───────────────────────────────────────────
+MODEL_CONFIGS=(
+    "HojoAI/Hojo-ASR-Multi-V1      32"
+)
+
+# ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
+# German, French, Italian, Spanish, Portuguese
+DATASET_CONFIGS=(
+    "fleurs de"
+    "fleurs fr"
+    "fleurs it"
+    "fleurs es"
+    "fleurs pt"
+    "mcv de"
+    "mcv es"
+    "mcv fr"
+    "mcv it"
+    "mls es"
+    "mls fr"
+    "mls it"
+    "mls pt"
+)
+
+# ── Submit one job per model/dataset/language combination ───────────────────
+for model_cfg in "${MODEL_CONFIGS[@]}"; do
+    read -r MODEL_ID BATCH_SIZE <<< "$model_cfg"
+    # Sanitize model ID for use as a folder name (e.g. "nvidia/parakeet" -> "nvidia-parakeet")
+    MODEL_FOLDER="${MODEL_ID//\//-}"
+
+    echo "████████████████████████████████████████████████████████████████████████████████"
+    echo "  Evaluating: ${MODEL_ID}"
+    echo "████████████████████████████████████████████████████████████████████████████████"
+
+    for cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r DATASET LANGUAGE <<< "$cfg"
+        CONFIG_NAME="${DATASET}_${LANGUAGE}"
+        echo "Submitting job: model=${MODEL_ID} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
+
+        NAMESPACE_ARG=""
+        [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
+
+        hf jobs run \
+            --flavor "$FLAVOR" \
+            --timeout 8h \
+            --env HF_TOKEN="$HF_TOKEN" \
+            ${NAMESPACE_ARG} \
+            --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
+            "hf.co/spaces/${SPACE}" \
+            bash -c "
+                ${LOCAL_SCRIPT_INJECT}
+                PYTHONPATH=/app python run_eval_ml.py \
+                    --model_id=${MODEL_ID} \
+                    --dataset=${DATASET_PATH} \
+                    --config_name=${CONFIG_NAME} \
+                    --language=${LANGUAGE} \
+                    --split=test \
+                    --device=0 \
+                    --batch_size=${BATCH_SIZE} &&
+                mkdir -p /results/${MODEL_FOLDER} &&
+                cp results/*.jsonl /results/${MODEL_FOLDER}/
+            " > /dev/null 2>&1 &
+    done
+    if [ -n "$ORG_NAME" ]; then
+        echo "For live status see: https://huggingface.co/organizations/${ORG_NAME}/settings/jobs"
+    else
+        echo "For live status see: https://huggingface.co/settings/jobs"
+    fi
+
+    # Wait for all background job submissions to complete
+    wait
+    echo "All jobs finished."
+    sleep 10  # allow time for the last results to be flushed to the bucket
+
+    # Download results and score
+    mkdir -p "./results/${MODEL_FOLDER}"
+
+    hf buckets sync \
+        "hf://buckets/${RESULTS_BUCKET}/${MODEL_FOLDER}" \
+        "./results/${MODEL_FOLDER}" > /dev/null 2>&1
+
+    EXPECTED=${#DATASET_CONFIGS[@]}
+    ACTUAL=$(find "./results/${MODEL_FOLDER}" -name "*.jsonl" | wc -l)
+    if [[ "$ACTUAL" -lt "$EXPECTED" ]]; then
+        echo "WARNING: expected ${EXPECTED} result files but only found ${ACTUAL}. Some jobs may not have finished yet."
+    else
+        echo "All ${ACTUAL} result files present."
+    fi
+
+    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+    # Collect the set of languages actually evaluated (across all datasets)
+    ALL_LANGUAGES=()
+    for cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r DATASET LANGUAGE <<< "$cfg"
+        if [[ ! " ${ALL_LANGUAGES[*]} " == *" ${LANGUAGE} "* ]]; then
+            ALL_LANGUAGES+=("$LANGUAGE")
+        fi
+    done
+
+    # Evaluate results: one call per language, so each is normalized with the
+    # correct language-specific normalizer and only its "ml_<lang>" family
+    # CSV block is printed.
+    for LANGUAGE in "${ALL_LANGUAGES[@]}"; do
+        PYTHONPATH="${REPO_ROOT}" python -c "
+from normalizer.eval_utils import score_results
+score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}', multilingual=True, language='${LANGUAGE}', families=['mls_${LANGUAGE}'], csv_only=True)
+"
+    done
+
+done

--- a/hojo_asr/submit_jobs_ml.sh
+++ b/hojo_asr/submit_jobs_ml.sh
@@ -5,8 +5,8 @@
 # Usage: HF_TOKEN=hf_... bash submit_ml_jobs.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
-SPACE="${SPACE:-HojoAI/open-asr-leaderboard-hojo-asr}"
-RESULTS_BUCKET="${RESULTS_BUCKET:-HojoAI/openasr_eval}"
+SPACE="${SPACE:-hf-audio/open-asr-leaderboard-hojo-asr}"
+RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_multilingual}"
 DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard-multilingual-datasets}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"

--- a/hojo_asr/submit_jobs_ml.sh
+++ b/hojo_asr/submit_jobs_ml.sh
@@ -126,7 +126,7 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     for LANGUAGE in "${ALL_LANGUAGES[@]}"; do
         PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
-score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}', multilingual=True, language='${LANGUAGE}', families=['mls_${LANGUAGE}'], csv_only=True)
+score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}', multilingual=True, language='${LANGUAGE}', families=['ml_${LANGUAGE}'], csv_only=True)
 "
     done
 


### PR DESCRIPTION
## Description

Add Hojo-ASR-Mul-V1 model , a high-performance conversational speech recognition model powered by the Qwen3 LLM decoder. It adopts the classic Encoder-Adapter-LLM framework, fully leveraging acoustic fine-grained features and strong LLM semantic capabilities. The model further expands its full‑coverage multilingual recognition capacity, fully supporting major languages including German, French, Spanish, Portuguese, Japanese, Italian, Arabic, Korean and Russian.

Model repo result file:
https://huggingface.co/HojoAI/Hojo-ASR-Multi-V1/blob/main/.eval_results/open_asr_leaderboard.yaml

Raw JSONL manifests for maintainer verification:
https://huggingface.co/buckets/HojoAI/openasr_eval/tree/HojoAI-Hojo-ASR-Multi-V1

HF Jobs Space for reproduction:
https://huggingface.co/spaces/HojoAI/open-asr-leaderboard-hojo-asr

Results:

| Split                     |  WER |  RTFx |
|---------------------------|-----:|------:|
| fleurs_de          | 4.09 | 27.95 |
| fleurs_es           | 2.88| 38.63 |
| fleurs_fr            | 3.34 | 30.13 |
| fleurs_it            | 2.43 | 33.10 |
| fleurs_pt           | 3.82 | 37.37 |
| mcv_de             | 3.85 | 52.68 |
| mcv_es             | 3.27 | 62.51 |
| mcv_fr              | 4.52 | 55.21 |
| mcv_it              | 2.43 | 55.07 |
| mls_es              | 3.33 | 39.97 |
| mls_fr               | 2.95 | 37.90 |
| mls_it               | 5.35 | 39.55 |
| mls_pt              | 4.08 | 35.85 |

********************************************************************************
Composite Results:
********************************************************************************
HojoAI/Hojo-ASR-Multi-V1: WER = 3.56 %
HojoAI/Hojo-ASR-Multi-V1: RTFx = 48.79
********************************************************************************

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

Results are reported in the model repo:
https://huggingface.co/HojoAI/Hojo-ASR-Multi-V1/blob/main/.eval_results/open_asr_leaderboard.yaml

### HF Jobs evaluation (open-source models)

Using [HF Jobs](https://huggingface.co/docs/hub/en/jobs-overview) makes it straightforward for maintainers to reproduce and verify your results. There are configurations for multiple model libraries available [here](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations).

- [x] (If a custom configuration is needed) duplicate one of the Space above (click the ⋮ menu → **Duplicate this Space**) to create your own copy, e.g. `your-username/open-asr-leaderboard-mymodel`.
    - [x] Modify the `Dockerfile` to install your model's dependencies, e.g. installing from a specific version/fork of Transformers.
    - [x] Adapt `run_eval.py` for your model — use the [Transformers one](https://huggingface.co/spaces/hf-audio/open-asr-leaderboard-transformers/blob/main/run_eval.py) as a starting point. There is no need to modify/update the normalizer files, as the `run_eval.py` script should save the raw (un-normalized) transcripts and model outptus, and the normalizer from the repo is locally score the model outputs.
    - [ ] For models that use `trust_remote_code=True`, please default to a `revision` tag and specify it in your bash script. 
- [x] In this repo, create a folder for your model library and a `submit_jobs.sh` script (use any existing one in this repo as a template) pointing to your Space and a results bucket.

A similar checklist applies for multilingual evaluation (with `run_eval_ml.py` and `submit_jobs_ml.sh`).

####  Key guidelines
- [x] Use the **same decoding hyper-parameters** across all datasets for a given model.
- [x] (If writing a new) `run_eval.py`, it must support **batch processing** and use `normalizer/data_utils.py` for data loading, normalization, and manifest writing.
- [ ] Use the **maximum possible batch size** (can differ per dataset) on an H200 GPU.
- [ ] Use `torch.compile` and/or relevant optimizations including warmup to maximize RTFx.
- [ ] Even if you're not using HF Jobs, prepare an HF space like the [existing models](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations), such that the maintainers can reproduce your results on HF Jobs.
- [x] Please report your results on the relevant public sets, as well as the RTFx.
- [x] Be sure to count the **total number** of parameters. You can get the exact number by adding the following line in your `run_eval.py` script:
```python
print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
```
- [x] Please provide the following model metadata (see [here](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-results/blob/main/english_short_latest.csv) for existing models).

License | Size (B) | # Languages | Encoder | Decoder
-- | -- | -- | -- | --
 Apache-2.0 | 5.18 | 10 | Qwen3-Omni encoder | Qwen3-4B

- [x] Does the license appear on your model card? 

### My model is not in Transformers (yet 🙃)

- [x] Duplicate an [existing Space](https://huggingface.co/collections/hf-audio/open-asr-leaderboard-eval-configurations) that is closest to your model's framework, then modify the Dockerfile to install the required dependencies.
- [x] Adapt run_eval.py for your model's inference API (supports batch processing and relevant optimizations).
- [x] Create a submit_jobs_<your_model>.sh script pointing to your new Space, and include it in your PR.


## Related issues
Closes #