### PR TITLE
Add Sophea ASR K1 (KIEFER SA) — API model

### DIFF
--- a/api/providers/__init__.py
+++ b/api/providers/__init__.py
@@ -59,6 +59,7 @@ from . import (
     openai_provider,
     reson8_provider,
     revai_provider,
+    sophea_provider,
     smallest_provider,
     soniox_provider,
     speechmatics_provider,

--- a/api/providers/sophea_provider.py
+++ b/api/providers/sophea_provider.py
@@ -1,0 +1,33 @@
+import os
+from typing import Optional
+
+import requests
+
+from . import APIProvider, register
+
+
+@register("sophea")
+class SopheaProvider(APIProvider):
+    """Sophea ASR (KIEFER SA). Model variants: "asr-k1". Env: SOPHEA_API_KEY, SOPHEA_API_URL (default https://api.sophea.ai)."""
+
+    def transcribe(
+        self,
+        model_variant: str,
+        audio_file_path: Optional[str],
+        sample: dict,
+        use_url: bool = False,
+        language: str = "en",
+        prompt: Optional[str] = None,
+    ) -> str:
+        base = os.getenv("SOPHEA_API_URL", "https://api.sophea.ai").rstrip("/")
+        headers = {"X-API-Key": os.environ["SOPHEA_API_KEY"]}
+        data = {"model": model_variant, "language": language or "en"}
+        if use_url:
+            audio_bytes = requests.get(sample["row"]["audio"][0]["src"], timeout=60).content
+            files = {"file": ("audio", audio_bytes)}
+        else:
+            with open(audio_file_path, "rb") as f:
+                files = {"file": (os.path.basename(audio_file_path), f.read())}
+        r = requests.post(f"{base}/v1/transcribe", headers=headers, files=files, data=data, timeout=300)
+        r.raise_for_status()
+        return r.json()["text"]

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -76,7 +76,7 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
 
         docker run --rm \
             --user "$(id -u):$(id -g)" \
-            -e HF_TOKEN="${HF_TOKEN:-}"
+            -e HF_TOKEN="${HF_TOKEN:-}" \
             -e SOPHEA_API_KEY="${SOPHEA_API_KEY:-}" -e SOPHEA_API_URL="${SOPHEA_API_URL:-}" \
             -e HF_HOME=/tmp/hf_home \
             -e HF_DATASETS_CACHE=/hf_cache/datasets \

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -29,6 +29,7 @@ MODEL_CONFIGS=(
     # "modulate/vfast                25"
     # "gladia/solaria-3             20"
     # "soniox/stt-async-v5           20"
+    # "sophea/asr-k1                 16"
 )
 DATASET_PATH="hf-audio/open-asr-leaderboard"
 
@@ -75,7 +76,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
 
         docker run --rm \
             --user "$(id -u):$(id -g)" \
-            -e HF_TOKEN="${HF_TOKEN:-}" \
+            -e HF_TOKEN="${HF_TOKEN:-}"
+            -e SOPHEA_API_KEY="${SOPHEA_API_KEY:-}" -e SOPHEA_API_URL="${SOPHEA_API_URL:-}" \
             -e HF_HOME=/tmp/hf_home \
             -e HF_DATASETS_CACHE=/hf_cache/datasets \
             -e NUMBA_CACHE_DIR=/tmp/numba_cache \


### PR DESCRIPTION
## Description
Adds **Sophea ASR K1** (`sophea/asr-k1`), a proprietary English/Greek speech-recognition system by KIEFER SA (Sophea), as an API model.
`api/providers/sophea_provider.py` posts the audio file to our HTTPS endpoint (`POST /v1/transcribe`, multipart `file`, `language`)
and returns the transcript. Same decoding configuration for every dataset (no per-dataset settings; forced English).

Run with the existing harness:
```bash
SOPHEA_API_KEY=<key> SOPHEA_API_URL=<url> MODEL="sophea/asr-k1 16" bash api/run_api.sh
```

## Type of change
- [x] New model (API)

## API model checklist
- [x] Provider file `api/providers/sophea_provider.py`, imported in `api/providers/__init__.py`
- [x] `api/run_api.sh`: `MODEL_CONFIGS` entry (`sophea/asr-k1 16`) and `SOPHEA_API_KEY` / `SOPHEA_API_URL` passed to `docker run`
- [x] API key + endpoint URL will be sent to the maintainers (Eric Bezzam / Steven Zheng) privately
- [x] Documentation link: https://huggingface.co/spaces/KIEFERSA/sophea-asr-k1-docs

| # Languages | Cost ($/hour) | Link to model announcement or API |
|---|---|---|
| 2 (English, Greek) | pilot pricing on request (registration opening soon) | https://huggingface.co/spaces/KIEFERSA/sophea-asr-k1-docs |

## Results (public English short-form, obtained with this repo's `api/run_eval.py` + `normalizer` against the same endpoint)
| AMI-Cleaned | Earnings22 | Gigaspeech-Cleaned | LS Clean | LS Other | SPGISpeech | Voxpopuli-AA-Cleaned | **Avg (cleaned)** |
|---|---|---|---|---|---|---|---|
| 7.29 | 8.22 | 7.66 | 1.17 | 2.69 | 2.71 | 2.89 | **4.66** |

Original variants (raw AMI / Gigaspeech / Voxpopuli) also available on request. Metadata: License = Proprietary; two-model system
(a Qwen3-ASR-1.7B–based far-field-repaired model and a Canary-1B-v2–based model, per-clip confidence-arbitrated); no leaderboard test split
was used for training or calibration.
