### PR TITLE
Add support for AA-Earnings-Cleaned set

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ The Open ASR Leaderboard evaluates models on a diverse set of publicly available
 * **Main Test Sets (English, short-form):**
   The main benchmark datasets used for evaluation (short-form English) are available [here](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard).
 
+* **Chunked sets with session-level references:**
+  [**Earnings22-Cleaned-AA-chunked**](https://huggingface.co/datasets/ArtificialAnalysis/Earnings22-Cleaned-AA-chunked) splits 6 earnings calls into 341 chunks, with one reference transcript per call in the parent [Earnings22-Cleaned-AA](https://huggingface.co/datasets/ArtificialAnalysis/Earnings22-Cleaned-AA) set. Models transcribe each chunk as usual; the scorer concatenates a call's chunk predictions before computing WER against the call-level reference. Run with `--dataset_path ArtificialAnalysis/Earnings22-Cleaned-AA-chunked --dataset earnings22_cleaned_aa_chunked --split test`.
+
 * **English, long-form:**
   The [**ASR Longform benchmark**](https://huggingface.co/datasets/hf-audio/asr-leaderboard-longform) dataset includes earnings21 and earnings22. We also evaluate on [CORAAL](https://huggingface.co/datasets/bezzam/coraal), but it is stored as a separate dataset since it has multiple splits.
 

--- a/abr/run_eval.py
+++ b/abr/run_eval.py
@@ -141,6 +141,8 @@ def main(args):
         remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -148,6 +150,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -164,11 +168,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/abr/submit_jobs.sh
+++ b/abr/submit_jobs.sh
@@ -5,12 +5,33 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-abr}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 BATCH_SIZE=512
 WARMUP_STEPS=5
 SUBBATCH_SAMPLES=30000000
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id revision" ──────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -18,10 +39,11 @@ MODEL_CONFIGS=(
     "abr-ai/niagara-38m-batch.en 4f3ec18d377b1fd01e94d15dc9b9db0a8cd74bd2"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned test"
     "librispeech test.clean"
     "librispeech test.other"
@@ -39,9 +61,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -55,6 +78,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --revision=${REVISION} \
@@ -92,7 +117,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -25,16 +25,18 @@ MODEL_CONFIGS=(
     # "smallestai/pulse              16"
     # "reson8/resonant-1             16"
     # "reson8/resonant-1-flash       16"
-    # "microsoft/azure-speech-05-2026  4"
+    # "microsoft/azure-speech-06-2026  4"
     # "modulate/vfast                25"
     # "gladia/solaria-3             20"
     # "soniox/stt-async-v5           20"
 )
-DATASET_PATH="hf-audio/open-asr-leaderboard"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 
+# ── Datasets: "name:split[:dataset_path]" ────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 EVAL_DATASETS=(
     "ami_cleaned:test"
-    "earnings22:test"
+    "earnings22_cleaned_aa_chunked:test:ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned:test"
     "librispeech:test.clean"
     "librispeech:test.other"
@@ -57,6 +59,10 @@ LEXICAL_DATASETS="librispeech gigaspeech"
 RUNDIR="${REPO_ROOT}"
 HF_CACHE_DIR="${HF_HOME:-$HOME/.cache/huggingface}"
 
+# Create the bind-mount sources up front: Docker would otherwise create them
+# as root, and the containers run as the current user (see --user below).
+mkdir -p "${RUNDIR}/results" "${HF_CACHE_DIR}"
+
 echo "Building Docker image ${IMAGE_TAG} (context: ${REPO_ROOT})..."
 docker build -f "${REPO_ROOT}/Dockerfile" -t "${IMAGE_TAG}" "${REPO_ROOT}"
 
@@ -65,8 +71,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     MODEL_FOLDER="${MODEL_ID//\//-}"
 
     for entry in "${EVAL_DATASETS[@]}"; do
-        DATASET="${entry%%:*}"
-        SPLIT="${entry##*:}"
+        IFS=":" read -r DATASET SPLIT DATASET_PATH <<< "$entry"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
         PROMPT_FLAG=""
         if [[ "$MODEL_ID" == microsoft/* ]] && [[ " $LEXICAL_DATASETS " == *" $DATASET "* ]]; then
@@ -78,6 +84,7 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             -e HF_TOKEN="${HF_TOKEN:-}" \
             -e HF_HOME=/tmp/hf_home \
             -e HF_DATASETS_CACHE=/hf_cache/datasets \
+            -e HF_HUB_CACHE=/hf_cache/hub \
             -e NUMBA_CACHE_DIR=/tmp/numba_cache \
             -e MODULATE_API_KEY="${MODULATE_API_KEY:-}" \
             -e GLADIA_API_KEY="${GLADIA_API_KEY:-}" \
@@ -128,12 +135,11 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
 
     if [[ -n "${RESULTS_BUCKET}" ]]; then
         # Only upload the specific files for the datasets in EVAL_DATASETS
-        DATASET_PATH_SLUG="${DATASET_PATH//\//-}"
         INCLUDE_ARGS=()
         for entry in "${EVAL_DATASETS[@]}"; do
-            _DS="${entry%%:*}"
-            _SP="${entry##*:}"
-            FNAME="MODEL_${MODEL_FOLDER}_DATASET_${DATASET_PATH_SLUG}_${_DS}_${_SP}.jsonl"
+            IFS=":" read -r _DS _SP _DP <<< "$entry"
+            _DP="${_DP:-$DEFAULT_DATASET_PATH}"
+            FNAME="MODEL_${MODEL_FOLDER}_DATASET_${_DP//\//-}_${_DS}_${_SP}.jsonl"
             if [[ -f "${MODEL_RESULTS_DIR}/${FNAME}" ]]; then
                 INCLUDE_ARGS+=(--include "${FNAME}")
             else

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -67,6 +67,10 @@ LEXICAL_DATASETS="mls-it"
 RUNDIR="${REPO_ROOT}"
 HF_CACHE_DIR="${HF_HOME:-$HOME/.cache/huggingface}"
 
+# Create the bind-mount sources up front: Docker would otherwise create them
+# as root, and the containers run as the current user (see --user below).
+mkdir -p "${RUNDIR}/results" "${HF_CACHE_DIR}"
+
 echo "Building Docker image ${IMAGE_TAG} (context: ${REPO_ROOT})..."
 docker build -f "${REPO_ROOT}/Dockerfile" -t "${IMAGE_TAG}" "${REPO_ROOT}"
 

--- a/api/run_eval.py
+++ b/api/run_eval.py
@@ -1,6 +1,5 @@
 import argparse
 from typing import Optional
-import datasets
 import soundfile as sf
 import tempfile
 import time
@@ -105,13 +104,27 @@ def transcribe_dataset(
     max_workers=4,
     prompt=None,
 ):
+    is_chunked = data_utils.is_chunked_dataset(dataset_path)
+
     if use_url:
+        if is_chunked:
+            raise ValueError(
+                f"{dataset_path} is a chunked dataset whose audio is not referenced by "
+                "the rows API, run without --use_url."
+            )
         audio_rows = fetch_audio_urls(dataset_path, dataset, split)
         if max_samples:
             audio_rows = itertools.islice(audio_rows, max_samples)
         ds = audio_rows
     else:
-        ds = datasets.load_dataset(dataset_path, dataset, split=split, streaming=False)
+        ds = data_utils.load_data(
+            argparse.Namespace(
+                dataset_path=dataset_path,
+                dataset=dataset,
+                split=split,
+                streaming=False,
+            )
+        )
         ds = data_utils.prepare_data(ds)
         if max_samples:
             ds = ds.take(max_samples)
@@ -122,6 +135,8 @@ def transcribe_dataset(
         "audio_length_s": [],
         "transcription_time_s": [],
     }
+    if is_chunked:
+        results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
 
     print(f"Transcribing with model: {model_name}")
 
@@ -165,7 +180,18 @@ def transcribe_dataset(
                     os.unlink(tmp_path)
 
         transcription_time = time.time() - start
-        return reference, transcription, audio_duration, transcription_time
+        chunk_metadata = (
+            {key: sample[key] for key in data_utils.CHUNK_METADATA_KEYS}
+            if is_chunked
+            else {}
+        )
+        return (
+            reference,
+            transcription,
+            audio_duration,
+            transcription_time,
+            chunk_metadata,
+        )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_sample = {
@@ -176,11 +202,19 @@ def transcribe_dataset(
             total=len(future_to_sample),
             desc="Transcribing",
         ):
-            reference, transcription, audio_duration, transcription_time = future.result()
+            (
+                reference,
+                transcription,
+                audio_duration,
+                transcription_time,
+                chunk_metadata,
+            ) = future.result()
             results["predictions"].append(transcription)
             results["references"].append(reference)
             results["audio_length_s"].append(audio_duration)
             results["transcription_time_s"].append(transcription_time)
+            for key, value in chunk_metadata.items():
+                results[key].append(value)
 
     manifest_path = data_utils.write_manifest(
         results["references"],
@@ -191,12 +225,25 @@ def transcribe_dataset(
         split,
         audio_length=results["audio_length_s"],
         transcription_time=results["transcription_time_s"],
+        extra_fields={key: results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
 
     print("Results saved at path:", manifest_path)
 
-    norm_refs = [data_utils.normalizer(r) for r in results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(
+            data_utils.read_manifest(manifest_path)
+        )
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = results["references"]
+        predictions = results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     refs_split = [tuple(r.split()) for r in norm_refs]
     preds_split = [tuple(p.split()) for p in norm_preds]
     wer = round(100 * batch_error_rate(refs_split, preds_split, merge_compounds=True)["err_rate"], 2)

--- a/api/submit_jobs.sh
+++ b/api/submit_jobs.sh
@@ -15,10 +15,31 @@
 # Global defaults (can be left as-is; per-model `max_workers` will override)
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-apis}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 # API jobs are CPU-only (no model weights loaded locally)
 FLAVOR="${FLAVOR:-cpu-basic}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 
 # ── Models: "model_id max_workers" ──────────────────────────────────────────
@@ -37,15 +58,16 @@ MODEL_CONFIGS=(
     # "speechmatics/enhanced         8"    # `cpu-xl` needed for spgispeech
     # "aquavoice/avalon-v1-en        16"
     # "zoom/scribe_v1                32"
-    # "microsoft/azure-speech-05-2026  4"
+    # "microsoft/azure-speech-06-2026  4"
     # "reson8/resonant-1             16"
     # "reson8/resonant-1-flash       16"
 )
 
-# ── Datasets ──────────────────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned test"
     "librispeech test.clean"
     "librispeech test.other"
@@ -66,14 +88,15 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
         PROMPT_ARG=""
         if [[ "$MODEL_ID" == microsoft/* ]] && [[ " $LEXICAL_DATASETS " == *" $DATASET "* ]]; then
             PROMPT_ARG="--prompt 'Output must be in lexical format.'"
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -96,6 +119,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --dataset_path=${DATASET_PATH} \
                     --dataset=${DATASET} \
@@ -130,7 +155,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/ark_asr/run_eval.py
+++ b/ark_asr/run_eval.py
@@ -1,0 +1,692 @@
+import argparse
+import os
+
+# Force soundfile audio decoding before datasets is imported/used,
+# to avoid the torchcodec AudioDecoder object being returned.
+os.environ.setdefault("HF_AUDIO_DECODER_BACKEND", "soundfile")
+
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+import pyarrow.parquet as pq
+import soundfile as sf
+import torch
+from datasets import Audio, load_dataset
+from kaldialign import edit_distance as kaldi_edit_distance
+from normalizer import data_utils
+from torch import Tensor
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
+from transformers.generation.logits_process import LogitsProcessor, LogitsProcessorList
+
+SPECIAL_TOKEN_PATTERN = re.compile(
+    r"<\|(?:"
+    r"bicodec_(?:semantic|global)_\d+|"
+    r"(?:start|end)_(?:global_token|glm_token|semantic_token|content)"
+    r")\|>"
+)
+TURN_END_MARKERS = ("<|user|>", "<|assistant|>", "<|im_end|>")
+LEADING_NOISE_PATTERN = re.compile(r"^[\s,.;:!?-]+")
+CONTROL_TOKEN_PATTERN = re.compile(r"^<.*>$")
+
+
+class BlockTokenIdsFromLogitsProcessor(LogitsProcessor):
+    def __init__(self, block_from_id: int | None, block_token_ids: Iterable[int] | None = None):
+        self.block_from_id = None if block_from_id is None or int(block_from_id) < 0 else int(block_from_id)
+        self.block_token_ids = sorted(set(int(token_id) for token_id in (block_token_ids or [])))
+
+    def __call__(self, input_ids: Tensor, scores: Tensor) -> Tensor:
+        vocab_size = scores.shape[-1]
+        if self.block_from_id is not None and self.block_from_id < vocab_size:
+            scores[:, self.block_from_id :] = -float("inf")
+        valid_token_ids = [token_id for token_id in self.block_token_ids if 0 <= token_id < vocab_size]
+        if valid_token_ids:
+            scores[:, valid_token_ids] = -float("inf")
+        return scores
+
+
+def normalize_token_ids(token_ids: Any) -> list[int]:
+    if token_ids is None:
+        return []
+    if isinstance(token_ids, (list, tuple, set)):
+        return [int(token_id) for token_id in token_ids if token_id is not None]
+    return [int(token_ids)]
+
+
+def build_eos_token_ids(tokenizer: Any) -> list[int]:
+    eos_ids = []
+    eos_ids.extend(normalize_token_ids(getattr(tokenizer, "eos_token_id", None)))
+    for marker in TURN_END_MARKERS:
+        token_id = tokenizer.convert_tokens_to_ids(marker)
+        if isinstance(token_id, int) and token_id >= 0:
+            eos_ids.append(int(token_id))
+    return list(dict.fromkeys(eos_ids))
+
+
+def build_asr_keep_token_ids(model: Any, tokenizer: Any) -> list[int]:
+    keep_token_ids = set()
+    keep_token_ids.update(normalize_token_ids(getattr(tokenizer, "eos_token_id", None)))
+    keep_token_ids.update(normalize_token_ids(getattr(getattr(model, "config", None), "eos_token_id", None)))
+    keep_token_ids.update(normalize_token_ids(getattr(getattr(model, "generation_config", None), "eos_token_id", None)))
+    return sorted(keep_token_ids)
+
+
+def build_asr_extra_block_token_ids(
+    tokenizer: Any,
+    keep_token_ids: Iterable[int] | None = None,
+    block_from_id: int | None = None,
+) -> list[int]:
+    keep = set(int(token_id) for token_id in (keep_token_ids or []))
+    max_control_token_id = None if block_from_id is None or int(block_from_id) < 0 else int(block_from_id)
+    block_token_ids = set(int(token_id) for token_id in getattr(tokenizer, "all_special_ids", []) if token_id is not None)
+    added_tokens_decoder = getattr(tokenizer, "added_tokens_decoder", {}) or {}
+    for token_id, token_meta in added_tokens_decoder.items():
+        token_id = int(token_id)
+        if max_control_token_id is not None and token_id >= max_control_token_id:
+            continue
+        token_content = getattr(token_meta, "content", None)
+        if token_content is None and isinstance(token_meta, dict):
+            token_content = token_meta.get("content")
+        if token_content and CONTROL_TOKEN_PATTERN.match(token_content):
+            block_token_ids.add(token_id)
+    block_token_ids.difference_update(keep)
+    return sorted(block_token_ids)
+
+
+def as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "keys") and hasattr(value, "__getitem__"):
+        return {key: value[key] for key in value.keys()}
+    raise TypeError(f"Unexpected processor output type: {type(value)}")
+
+
+def truncate_generation_text(text: str) -> str:
+    if not text:
+        return ""
+    cut = len(text)
+    for marker in TURN_END_MARKERS:
+        index = text.find(marker)
+        if index != -1 and index < cut:
+            cut = index
+    return text[:cut].strip()
+
+
+def remove_special_tokens(text: str) -> str:
+    if not text:
+        return ""
+    if "<|text|>" in text:
+        text = text.split("<|text|>", 1)[1]
+    return SPECIAL_TOKEN_PATTERN.sub("", text).strip()
+
+
+def clean_prediction_text(text: str) -> str:
+    if not text:
+        return ""
+    text = truncate_generation_text(text)
+    text = remove_special_tokens(text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return LEADING_NOISE_PATTERN.sub("", text).strip()
+
+
+def compute_wer_with_compounds(references: list[str], predictions: list[str]) -> float:
+    total_ins = total_del = total_sub = total_ref_words = 0
+    for ref, pred in zip(references, predictions):
+        ref_words = ref.split()
+        pred_words = pred.split()
+        if not ref_words:
+            total_ins += len(pred_words)
+            continue
+        result = kaldi_edit_distance(ref_words, pred_words, merge_compounds=True)
+        total_ins += result["ins"]
+        total_del += result["del"]
+        total_sub += result["sub"]
+        total_ref_words += result["ref_len"]
+
+    total_errors = total_ins + total_del + total_sub
+    return total_errors / total_ref_words if total_ref_words > 0 else 0.0
+
+
+def resolve_device(device_index: int) -> str:
+    if device_index >= 0:
+        return f"cuda:{device_index}"
+    return "cpu"
+
+
+def resolve_torch_dtype(dtype_name: str, device: str) -> torch.dtype:
+    if dtype_name == "auto":
+        return torch.float16 if device.startswith("cuda") else torch.float32
+    mapping = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }
+    if dtype_name not in mapping:
+        raise ValueError(f"Unsupported dtype: {dtype_name}")
+    if not device.startswith("cuda") and mapping[dtype_name] != torch.float32:
+        print(f"Warning: dtype={dtype_name} on {device} is not well supported. Falling back to float32.")
+        return torch.float32
+    return mapping[dtype_name]
+
+
+def limit_cuda_memory(device: str, limit_gb: float | None) -> None:
+    if limit_gb is None or limit_gb <= 0 or not device.startswith("cuda"):
+        return
+    if ":" in device:
+        device_index = int(device.split(":", 1)[1])
+    else:
+        device_index = torch.cuda.current_device()
+    total_memory = torch.cuda.get_device_properties(device_index).total_memory
+    fraction = min(float(limit_gb) * (1024 ** 3) / total_memory, 1.0)
+    torch.cuda.set_per_process_memory_fraction(fraction, device=device_index)
+
+
+def load_model(model_id: str, device: str, torch_dtype: torch.dtype, attn_impl: str, revision: str | None = None):
+    if attn_impl == "auto":
+        candidates = ["flash_attention_2", "sdpa"] if device.startswith("cuda") else ["eager"]
+    else:
+        candidates = [attn_impl]
+        if attn_impl == "flash_attention_2":
+            candidates.extend(["sdpa", "eager"] if device.startswith("cuda") else ["eager"])
+
+    last_error: Exception | None = None
+    for candidate in candidates:
+        try:
+            model = AutoModelForCausalLM.from_pretrained(
+                model_id,
+                trust_remote_code=True,
+                torch_dtype=torch_dtype,
+                attn_implementation=candidate,
+                revision=revision,
+            ).to(device)
+            model.eval()
+            return model, candidate
+        except (ImportError, RuntimeError, ValueError) as exc:
+            message = str(exc)
+            can_fallback = candidate == "flash_attention_2" and (
+                "flash_attn" in message or "FlashAttention" in message
+            )
+            if not can_fallback:
+                raise
+            print(f"Warning: attn_impl={candidate} unavailable ({message.splitlines()[0]}). Falling back.")
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("Failed to load model with any attention implementation.")
+
+
+def apply_audio_gain(audios: Tensor, gain: float) -> Tensor:
+    gain = float(gain)
+    if gain == 1.0:
+        return audios
+    return torch.clamp(audios.float() * gain, min=-1.0, max=1.0)
+
+
+def prepare_dataset(args):
+    if args.dataset_revision:
+        dataset = load_dataset(
+            args.dataset_path,
+            args.dataset,
+            split=args.split,
+            token=data_utils.get_hf_token(),
+            revision=args.dataset_revision,
+        )
+    else:
+        dataset = data_utils.load_data(args)
+
+    if args.audio_decode == "datasets":
+        return data_utils.prepare_data(dataset, sampling_rate=args.target_sr)
+
+    dataset = dataset.cast_column("audio", Audio(decode=False))
+    dataset = dataset.map(data_utils.normalize)
+    return dataset.filter(data_utils.is_target_text_in_range, input_columns=["norm_text"])
+
+
+def iter_local_parquet_batches(
+    local_parquet_dir: str,
+    *,
+    batch_size: int,
+    skip_samples: int,
+    max_samples: int | None,
+) -> Iterable[dict[str, list[Any]]]:
+    parquet_files = sorted(Path(local_parquet_dir).glob("*.parquet"))
+    if not parquet_files:
+        raise RuntimeError(f"No parquet files found under {local_parquet_dir}")
+
+    yielded = 0
+    seen = 0
+    batch = {"audio": [], "norm_text": [], "original_text": [], "audio_filepath": []}
+    for parquet_file in parquet_files:
+        pf = pq.ParquetFile(parquet_file)
+        for row_group_index in range(pf.num_row_groups):
+            rows = pf.read_row_group(row_group_index).to_pylist()
+            for row in rows:
+                original_text = data_utils.get_text(row)
+                normalized_text = data_utils.normalizer(original_text)
+                if not data_utils.is_target_text_in_range(normalized_text):
+                    continue
+                if seen < skip_samples:
+                    seen += 1
+                    continue
+                if max_samples is not None and max_samples > 0 and yielded >= max_samples:
+                    if batch["audio"]:
+                        yield batch
+                    return
+
+                batch["audio"].append(row["audio"])
+                batch["norm_text"].append(normalized_text)
+                batch["original_text"].append(original_text)
+                batch["audio_filepath"].append(data_utils.extract_audio_filepath_from_sample(row))
+                yielded += 1
+                seen += 1
+                if len(batch["audio"]) >= batch_size:
+                    yield batch
+                    batch = {"audio": [], "norm_text": [], "original_text": [], "audio_filepath": []}
+
+    if batch["audio"]:
+        yield batch
+
+
+def pad_audio_to_min_seconds(audio: np.ndarray, sampling_rate: int, min_seconds: float) -> np.ndarray:
+    if min_seconds <= 0:
+        return audio
+    min_samples = int(round(min_seconds * sampling_rate))
+    if len(audio) >= min_samples:
+        return audio
+    return np.pad(audio, (0, min_samples - len(audio)), mode="constant")
+
+
+class TemporaryWavBatch:
+    def __init__(self, audios: list[np.ndarray], sampling_rates: list[int], enabled: bool) -> None:
+        self.audios = audios
+        self.sampling_rates = sampling_rates
+        self.enabled = enabled
+        self.tempdir: tempfile.TemporaryDirectory[str] | None = None
+
+    def __enter__(self) -> list[str | dict[str, Any]]:
+        if not self.enabled:
+            return [
+                {"array": audio, "sampling_rate": sampling_rate}
+                for audio, sampling_rate in zip(self.audios, self.sampling_rates)
+            ]
+
+        self.tempdir = tempfile.TemporaryDirectory(prefix="ark_asr_eval_")
+        audio_paths = []
+        for index, (audio, sampling_rate) in enumerate(zip(self.audios, self.sampling_rates)):
+            path = Path(self.tempdir.name) / f"sample_{index}.wav"
+            sf.write(path, audio, sampling_rate)
+            audio_paths.append(str(path))
+        return audio_paths
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self.tempdir is not None:
+            self.tempdir.cleanup()
+
+
+class ArkAsrInferencer:
+    def __init__(
+        self,
+        model_id: str,
+        processor_id: str | None,
+        *,
+        device: str,
+        dtype: str,
+        attn_impl: str,
+        padding_side: str,
+        asr_block_token_id_from: int,
+        model_revision: str | None = None,
+    ) -> None:
+        self.device = device
+        self.torch_dtype = resolve_torch_dtype(dtype, device)
+        self.model, self.resolved_attn_impl = load_model(model_id, device, self.torch_dtype, attn_impl, revision=model_revision)
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_id,
+            trust_remote_code=True,
+            fix_mistral_regex=True,
+            revision=model_revision,
+        )
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        self.tokenizer.padding_side = padding_side
+        self.processor = AutoProcessor.from_pretrained(
+            processor_id or model_id,
+            trust_remote_code=True,
+            fix_mistral_regex=True,
+            revision=model_revision,
+        )
+        if hasattr(self.processor, "tokenizer"):
+            if self.processor.tokenizer.pad_token_id is None:
+                self.processor.tokenizer.pad_token_id = self.tokenizer.pad_token_id
+            self.processor.tokenizer.padding_side = padding_side
+        self.eos_token_ids = build_eos_token_ids(self.tokenizer)
+        keep_token_ids = build_asr_keep_token_ids(self.model, self.tokenizer)
+        self.extra_block_token_ids = build_asr_extra_block_token_ids(
+            self.tokenizer,
+            keep_token_ids=keep_token_ids,
+            block_from_id=asr_block_token_id_from,
+        )
+        self.asr_block_token_id_from = asr_block_token_id_from
+
+    def transcribe(
+        self,
+        audio_inputs: list[str | dict[str, Any]],
+        *,
+        target_sr: int,
+        max_audio_seconds: int,
+        max_new_tokens: int,
+        do_sample: bool,
+        temperature: float,
+        repetition_penalty: float,
+        audio_gain: float,
+    ) -> list[str]:
+        conversations = []
+        for audio_input in audio_inputs:
+            audio_content = {"type": "audio"}
+            if isinstance(audio_input, str):
+                audio_content["path"] = audio_input
+            else:
+                audio_content.update(audio_input)
+            conversations.append(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            audio_content,
+                            {"type": "text", "text": "Please transcribe this audio."},
+                        ],
+                    }
+                ]
+            )
+
+        inputs_raw = self.processor.apply_chat_template(
+            conversations,
+            return_tensors="pt",
+            sampling_rate=target_sr,
+            audio_padding="longest",
+            add_generation_prompt=True,
+            text_kwargs={"padding": "longest"},
+            audio_max_length=int(max_audio_seconds * target_sr),
+        )
+        if torch.is_tensor(inputs_raw):
+            raise RuntimeError("ASR apply_chat_template returned Tensor-only; audio was not encoded.")
+        inputs = as_dict(inputs_raw)
+        if "audios" not in inputs:
+            raise RuntimeError(f"ASR inputs missing 'audios'; processor keys={list(inputs.keys())}")
+        if "attention_mask" not in inputs and "input_ids" in inputs and torch.is_tensor(inputs["input_ids"]):
+            inputs["attention_mask"] = torch.ones_like(inputs["input_ids"], dtype=torch.long)
+
+        for key, value in list(inputs.items()):
+            if not torch.is_tensor(value):
+                continue
+            if key == "audios":
+                inputs[key] = apply_audio_gain(value, audio_gain).to(device=self.device, dtype=self.torch_dtype)
+            else:
+                inputs[key] = value.to(self.device)
+
+        generate_kwargs: dict[str, Any] = {
+            "max_new_tokens": max_new_tokens,
+            "do_sample": do_sample,
+            "pad_token_id": self.tokenizer.pad_token_id,
+        }
+        if self.eos_token_ids:
+            generate_kwargs["eos_token_id"] = self.eos_token_ids
+        if do_sample:
+            generate_kwargs["temperature"] = temperature
+        if repetition_penalty is not None:
+            generate_kwargs["repetition_penalty"] = repetition_penalty
+        if self.asr_block_token_id_from >= 0 or self.extra_block_token_ids:
+            generate_kwargs["logits_processor"] = LogitsProcessorList(
+                [
+                    BlockTokenIdsFromLogitsProcessor(
+                        block_from_id=self.asr_block_token_id_from,
+                        block_token_ids=self.extra_block_token_ids,
+                    )
+                ]
+            )
+
+        with torch.no_grad():
+            outputs = self.model.generate(**inputs, **generate_kwargs)
+
+        input_ids = inputs["input_ids"]
+        predictions = []
+        for index, output in enumerate(outputs):
+            generated_ids = output[len(input_ids[index].tolist()) :]
+            prediction_raw = self.tokenizer.decode(generated_ids, skip_special_tokens=False)
+            predictions.append(clean_prediction_text(prediction_raw))
+        return predictions
+
+
+def main(args):
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+    if is_chunked:
+        if args.local_parquet_dir:
+            raise ValueError(
+                "--local_parquet_dir cannot be used with a chunked dataset: the parquet "
+                "batches carry no chunk metadata to reassemble sessions with."
+            )
+        if args.dataset_revision:
+            raise ValueError(
+                "--dataset_revision cannot be used with a chunked dataset: chunked "
+                "datasets are loaded through data_utils.load_data."
+            )
+
+    device = resolve_device(args.device)
+    limit_cuda_memory(device, args.gpu_memory_limit_gb)
+    inferencer = ArkAsrInferencer(
+        args.model_id,
+        args.processor_id,
+        device=device,
+        dtype=args.dtype,
+        attn_impl=args.attn_impl,
+        padding_side=args.padding_side,
+        asr_block_token_id_from=args.asr_block_token_id_from,
+        model_revision=args.model_revision,
+    )
+    print(f"Loaded {args.model_id}; device={device}; attn={inferencer.resolved_attn_impl}; dtype={inferencer.torch_dtype}")
+    print(f"Model size: {sum(p.numel() for p in inferencer.model.parameters()) / 1e9:.2f}B parameters")
+
+    def benchmark(batch):
+        audios = [np.asarray(audio["array"], dtype=np.float32) for audio in batch["audio"]]
+        sampling_rate = batch["audio"][0]["sampling_rate"]
+        audios = [pad_audio_to_min_seconds(a, sampling_rate, args.min_audio_seconds) for a in audios]
+        minibatch_size = len(audios)
+        batch["audio_length_s"] = [len(a) / sampling_rate for a in audios]
+        batch["audio_filepath"] = data_utils.extract_audio_filepaths_from_batch(batch, minibatch_size)
+        sampling_rates = [sampling_rate] * minibatch_size
+
+        torch.cuda.synchronize(device=inferencer.device)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+
+        with TemporaryWavBatch(audios, sampling_rates, enabled=args.audio_input == "temp_wav") as audio_inputs:
+            pred_text = inferencer.transcribe(
+                audio_inputs,
+                target_sr=args.target_sr,
+                max_audio_seconds=args.max_audio_seconds,
+                max_new_tokens=args.max_new_tokens,
+                do_sample=args.do_sample,
+                temperature=args.temperature,
+                repetition_penalty=args.repetition_penalty,
+                audio_gain=args.audio_gain,
+            )
+
+        end_event.record()
+        torch.cuda.synchronize(device=inferencer.device)
+        runtime = start_event.elapsed_time(end_event) / 1000.0
+
+        batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
+        batch["predictions"] = pred_text
+        batch["references"] = batch["original_text"]
+        return batch
+
+    if args.warmup_steps is not None and args.warmup_steps > 0:
+        if args.local_parquet_dir:
+            print("Skipping warmup for local parquet input.")
+        else:
+            warmup_dataset = prepare_dataset(args)
+            num_warmup_samples = args.warmup_steps * args.batch_size
+            warmup_dataset = warmup_dataset.select(range(min(num_warmup_samples, len(warmup_dataset))))
+            warmup_dataset = iter(warmup_dataset.map(benchmark, batch_size=args.batch_size, batched=True))
+
+            for _ in tqdm(warmup_dataset, desc="Warming up..."):
+                continue
+
+    all_results = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+        "audio_filepath": [],
+    }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
+
+    if args.local_parquet_dir:
+        result_iter = (
+            benchmark(batch)
+            for batch in iter_local_parquet_batches(
+                args.local_parquet_dir,
+                batch_size=args.batch_size,
+                skip_samples=args.skip_eval_samples,
+                max_samples=args.max_eval_samples,
+            )
+        )
+        for batch_result in tqdm(result_iter, desc="Batches..."):
+            batch_len = len(batch_result["references"])
+            for index in range(batch_len):
+                for key in all_results:
+                    all_results[key].append(batch_result[key][index])
+    else:
+        warmup_dataset = prepare_dataset(args)
+        dataset = warmup_dataset
+
+        if args.skip_eval_samples is not None and args.skip_eval_samples > 0:
+            print(f"Skipping first {args.skip_eval_samples} samples!")
+            if args.skip_eval_samples >= len(dataset):
+                raise RuntimeError(
+                    f"skip_eval_samples={args.skip_eval_samples} leaves no samples "
+                    f"for {args.dataset}:{args.split}."
+                )
+            dataset = dataset.select(range(args.skip_eval_samples, len(dataset)))
+
+        if args.max_eval_samples is not None and args.max_eval_samples > 0:
+            print(f"Subsampling dataset to first {args.max_eval_samples} samples!")
+            dataset = dataset.select(range(min(args.max_eval_samples, len(dataset))))
+
+        dataset = dataset.map(
+            benchmark,
+            batch_size=args.batch_size,
+            batched=True,
+            remove_columns=["audio"],
+        )
+
+        result_iter = iter(dataset)
+        for result in tqdm(result_iter, desc="Samples..."):
+            for key in all_results:
+                all_results[key].append(result[key])
+
+    if not all_results["references"]:
+        raise RuntimeError(
+            f"No evaluation samples found for {args.dataset}:{args.split}. "
+            "Check the dataset config/files and filtering before writing a manifest."
+        )
+
+    manifest_path = data_utils.write_manifest(
+        all_results["references"],
+        all_results["predictions"],
+        args.model_id,
+        args.dataset_path,
+        args.dataset,
+        args.split,
+        audio_length=all_results["audio_length_s"],
+        transcription_time=all_results["transcription_time_s"],
+        audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
+    )
+    print("Results saved at path:", os.path.abspath(manifest_path))
+
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(ref) for ref in references]
+    norm_preds = [data_utils.normalizer(pred) for pred in predictions]
+    wer = round(100 * compute_wer_with_compounds(norm_refs, norm_preds), 2)
+    rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
+    print("WER:", wer, "%", "RTFx:", rtfx)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--model_id", type=str, required=True, help="ARK-ASR model path or Hugging Face repo id.")
+    parser.add_argument("--model_revision", type=str, default="e55e9b8cd6018ee8353007c3136e2fb2e77eef99", help="Model revision (commit SHA or tag) for trust_remote_code safety.")
+    parser.add_argument("--processor_id", type=str, default=None, help="Processor path or repo id. Defaults to model_id.")
+    parser.add_argument(
+        "--dataset_path",
+        type=str,
+        default="hf-audio/open-asr-leaderboard",
+        help="Dataset path. By default, it is `hf-audio/open-asr-leaderboard`.",
+    )
+    parser.add_argument("--dataset_revision", type=str, default=None, help="Optional Hugging Face dataset revision.")
+    parser.add_argument("--dataset", type=str, required=True, help="Dataset name.")
+    parser.add_argument("--split", type=str, default="test", help="Dataset split.")
+    parser.add_argument(
+        "--local_parquet_dir",
+        type=str,
+        default=None,
+        help="Optional local directory containing parquet shards for this dataset split.",
+    )
+    parser.add_argument("--device", type=int, default=-1, help="Device index. Use -1 for CPU.")
+    parser.add_argument("--gpu_memory_limit_gb", type=float, default=None, help="Optional per-process CUDA memory limit.")
+    parser.add_argument("--batch_size", type=int, default=16, help="Number of samples per batch.")
+    parser.add_argument("--skip_eval_samples", type=int, default=0, help="Number of prepared evaluation samples to skip.")
+    parser.add_argument("--max_eval_samples", type=int, default=None, help="Number of samples to evaluate.")
+    parser.add_argument("--max_new_tokens", type=int, default=256, help="Maximum number of tokens to generate.")
+    parser.add_argument("--warmup_steps", type=int, default=10, help="Number of warm-up batches.")
+    parser.add_argument("--target_sr", type=int, default=16000, help="Evaluation sampling rate.")
+    parser.add_argument("--min_audio_seconds", type=float, default=2.0, help="Right-pad audio shorter than this length.")
+    parser.add_argument(
+        "--audio_decode",
+        choices=["soundfile", "datasets"],
+        default="datasets",
+        help="Decode audio with soundfile or the default datasets.Audio decoder.",
+    )
+    parser.add_argument("--max_audio_seconds", type=int, default=40, help="Audio truncation length passed to the processor.")
+    parser.add_argument(
+        "--audio_input",
+        choices=["temp_wav", "array"],
+        default="array",
+        help="Pass audio through temporary 16 kHz WAV files or directly as arrays.",
+    )
+    parser.add_argument("--audio_gain", type=float, default=1.0)
+    parser.add_argument("--asr_block_token_id_from", type=int, default=151670)
+    parser.add_argument("--padding_side", choices=["left", "right"], default="left")
+    parser.add_argument("--attn_impl", choices=["auto", "flash_attention_2", "sdpa", "eager"], default="auto")
+    parser.add_argument("--dtype", choices=["auto", "float16", "bfloat16", "float32"], default="auto")
+    parser.add_argument("--do_sample", action="store_true")
+    parser.add_argument("--temperature", type=float, default=0.5)
+    parser.add_argument("--repetition_penalty", type=float, default=1.0)
+    parser.add_argument(
+        "--force_clean_exit",
+        action="store_true",
+        help="Exit with os._exit(0) after successful evaluation to bypass interpreter shutdown issues in some stacks.",
+    )
+    args = parser.parse_args()
+
+    main(args)
+    if args.force_clean_exit:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(0)

--- a/ark_asr/submit_jobs.sh
+++ b/ark_asr/submit_jobs.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-ark-asr}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id revision" ─────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -15,12 +36,13 @@ MODEL_CONFIGS=(
     "AutoArk-AI/ARK-ASR-3B    379a8f464c04ff11b4627a93721ca9982970bee4"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -36,9 +58,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -52,6 +75,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --model_revision=${MODEL_REVISION} \
@@ -88,7 +113,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/audio8_asr/run_eval.py
+++ b/audio8_asr/run_eval.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import os
+import random
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Sequence
+
+import librosa
+import numpy as np
+import pyarrow.parquet as pq
+import soundfile as sf
+import torch
+import torch.nn.functional as F
+from datasets import IterableDataset
+from kaldialign import batch_error_rate
+from transformers import AutoModelForCausalLM, AutoProcessor, CompileConfig
+
+from normalizer import data_utils
+
+
+DEFAULT_MODEL_ID = "AutoArk-AI/Audio8-ASR-0.1B"
+DEFAULT_MODEL_REVISION = "b812eff124893ecd76a1dcde74ee58db5adab59c"
+PROMPT = "Please transcribe this audio."
+
+
+@dataclass
+class LocalRow:
+    sample_id: str
+    reference: str
+    waveform: np.ndarray
+    sampling_rate: int
+    duration: float
+
+
+@dataclass
+class BatchOutput:
+    predictions: list[str]
+    generated_ids: list[list[int]]
+    runtime_seconds: float
+    stop_hits: list[bool]
+    max_new_hits: list[bool]
+    stop_token_ids: list[int | None]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate Audio8-ASR with the Open ASR Leaderboard contract.")
+    parser.add_argument("--model_id", default=DEFAULT_MODEL_ID)
+    parser.add_argument("--manifest_model_id")
+    parser.add_argument("--model_revision", default=DEFAULT_MODEL_REVISION)
+    parser.add_argument("--dataset_path", default="hf-audio/open-asr-leaderboard")
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--split", default="test")
+    parser.add_argument("--device", default="0")
+    parser.add_argument("--dtype", choices=("bfloat16", "float16", "float32"), default="bfloat16")
+    parser.add_argument("--attn_implementation", default="eager")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--max_eval_samples", type=int, default=-1)
+    parser.add_argument("--skip_samples", type=int, default=0)
+    parser.add_argument("--streaming", action="store_true")
+    parser.add_argument("--max_new_tokens", type=int, default=256)
+    parser.add_argument("--max_audio_seconds", type=float, default=30.0)
+    parser.add_argument("--sampling_rate", type=int, default=16000)
+    parser.add_argument("--model_max_length", type=int, default=1000)
+    parser.add_argument("--warmup_steps", type=int, default=1)
+    parser.add_argument("--feature_workers", type=int, default=int(os.environ.get("AUDIO8_FEATURE_WORKERS", "16")))
+    parser.add_argument("--torch_cpu_threads", type=int, default=int(os.environ.get("AUDIO8_TORCH_CPU_THREADS", "1")))
+    parser.add_argument("--torch_compile", choices=("default", "reduce-overhead", "max-autotune", "max-autotune-no-cudagraphs"))
+    parser.add_argument("--compile_fullgraph", action="store_true")
+    parser.add_argument("--local_files_only", action="store_true")
+    parser.add_argument("--local_parquet_dir", type=Path)
+    parser.add_argument("--local_parquet_file", type=Path, action="append", default=[])
+    parser.add_argument("--output_root", type=Path, default=Path("."))
+    return parser.parse_args()
+
+
+def resolve_device(value: str) -> torch.device:
+    value = str(value)
+    if value in {"-1", "cpu"}:
+        return torch.device("cpu")
+    if value.startswith("cuda"):
+        return torch.device(value)
+    return torch.device(f"cuda:{value}")
+
+
+def resolve_dtype(value: str, device: torch.device) -> torch.dtype:
+    if device.type != "cuda":
+        return torch.float32
+    return {
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[value]
+
+
+def unique_token_ids(values: Iterable[Any]) -> list[int]:
+    result: list[int] = []
+    for value in values:
+        children = value if isinstance(value, (list, tuple)) else [value]
+        for child in children:
+            if isinstance(child, int) and child >= 0 and child not in result:
+                result.append(child)
+    return result
+
+
+def build_conversation(waveform: np.ndarray) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio", "array": waveform},
+                {"type": "text", "text": PROMPT},
+            ],
+        }
+    ]
+
+
+def normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def waveform_from_audio_item(audio: Any, target_sampling_rate: int) -> tuple[np.ndarray, int]:
+    if isinstance(audio, dict):
+        waveform = audio.get("array")
+        sampling_rate = audio.get("sampling_rate", target_sampling_rate)
+    elif hasattr(audio, "get_all_samples"):
+        samples = audio.get_all_samples()
+        waveform = getattr(samples, "data", samples)
+        sampling_rate = getattr(samples, "sample_rate", target_sampling_rate)
+    else:
+        waveform = audio
+        sampling_rate = target_sampling_rate
+
+    if torch.is_tensor(waveform):
+        waveform = waveform.detach().cpu().float().numpy()
+    waveform = np.asarray(waveform, dtype=np.float32)
+    if waveform.ndim == 2:
+        channel_axis = 0 if waveform.shape[0] <= waveform.shape[1] else 1
+        waveform = waveform.mean(axis=channel_axis)
+    waveform = waveform.reshape(-1)
+    sampling_rate = int(sampling_rate)
+    if sampling_rate != int(target_sampling_rate):
+        waveform = librosa.resample(
+            waveform,
+            orig_sr=sampling_rate,
+            target_sr=int(target_sampling_rate),
+        )
+        sampling_rate = int(target_sampling_rate)
+    return np.asarray(waveform, dtype=np.float32), sampling_rate
+
+
+def parquet_paths(args: argparse.Namespace) -> list[Path]:
+    paths = [path.resolve() for path in args.local_parquet_file]
+    if args.local_parquet_dir is not None:
+        paths.extend(path.resolve() for path in sorted(args.local_parquet_dir.glob("*.parquet")))
+    unique: list[Path] = []
+    for path in paths:
+        if path not in unique:
+            unique.append(path)
+    missing = [str(path) for path in unique if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"Missing local Parquet files: {missing}")
+    return unique
+
+
+def row_sample_id(row: dict[str, Any], fallback_index: int) -> str:
+    for key in ("id", "wav_filename", "file", "path"):
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return f"sample_{fallback_index}"
+
+
+def decode_embedded_audio(row: dict[str, Any], sampling_rate: int) -> tuple[np.ndarray, float]:
+    audio = row.get("audio")
+    if isinstance(audio, dict):
+        audio_bytes = audio.get("bytes")
+    else:
+        audio_bytes = row.get("bytes")
+    if audio_bytes is None:
+        raise ValueError(f"Local Parquet row has no embedded audio bytes; keys={sorted(row)}")
+    decoded, original_sr = sf.read(io.BytesIO(bytes(audio_bytes)), dtype="float32", always_2d=True)
+    duration = float(decoded.shape[0]) / float(original_sr)
+    waveform = decoded.mean(axis=1)
+    if int(original_sr) != int(sampling_rate):
+        waveform = librosa.resample(waveform, orig_sr=int(original_sr), target_sr=int(sampling_rate))
+    return np.asarray(waveform, dtype=np.float32), duration
+
+
+def iter_local_rows(args: argparse.Namespace) -> Iterator[LocalRow]:
+    paths = parquet_paths(args)
+    if not paths:
+        raise ValueError("Local mode requires --local_parquet_dir or --local_parquet_file")
+    skipped = 0
+    emitted = 0
+    source_index = 0
+    for path in paths:
+        parquet = pq.ParquetFile(path)
+        for row_group_index in range(parquet.num_row_groups):
+            rows = parquet.read_row_group(row_group_index).to_pylist()
+            for row in rows:
+                reference = str(data_utils.get_text(row) or "")
+                normalized = data_utils.normalizer(reference)
+                if not data_utils.is_target_text_in_range(normalized):
+                    source_index += 1
+                    continue
+                if skipped < max(0, int(args.skip_samples)):
+                    skipped += 1
+                    source_index += 1
+                    continue
+                if args.max_eval_samples > 0 and emitted >= int(args.max_eval_samples):
+                    return
+                waveform, duration = decode_embedded_audio(row, args.sampling_rate)
+                yield LocalRow(
+                    sample_id=row_sample_id(row, source_index),
+                    reference=reference,
+                    waveform=waveform,
+                    sampling_rate=int(args.sampling_rate),
+                    duration=duration,
+                )
+                emitted += 1
+                source_index += 1
+
+
+def local_batch_from_rows(rows: Sequence[LocalRow]) -> dict[str, list[Any]]:
+    return {
+        "audio": [{"array": row.waveform, "sampling_rate": row.sampling_rate} for row in rows],
+        "original_text": [row.reference for row in rows],
+        "id": [row.sample_id for row in rows],
+    }
+
+
+def rows_to_batch(rows: Sequence[dict[str, Any]]) -> dict[str, list[Any]]:
+    keys: set[str] = set()
+    for row in rows:
+        keys.update(row.keys())
+    return {key: [row.get(key) for row in rows] for key in keys}
+
+
+def chunked_rows(rows: Iterable[Any], batch_size: int) -> Iterator[list[Any]]:
+    batch: list[Any] = []
+    for row in rows:
+        batch.append(row)
+        if len(batch) >= batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def iter_official_batches(dataset: Any, batch_size: int) -> Iterator[dict[str, list[Any]]]:
+    if isinstance(dataset, IterableDataset):
+        for rows in chunked_rows(iter(dataset), batch_size):
+            yield rows_to_batch(rows)
+        return
+    for start in range(0, len(dataset), batch_size):
+        yield dict(dataset[start : start + batch_size])
+
+
+def load_official_dataset(args: argparse.Namespace) -> Any:
+    dataset = data_utils.load_data(args)
+    dataset = data_utils.prepare_data(dataset, sampling_rate=args.sampling_rate)
+    if args.skip_samples > 0:
+        if isinstance(dataset, IterableDataset):
+            dataset = dataset.skip(int(args.skip_samples))
+        else:
+            dataset = dataset.select(range(min(int(args.skip_samples), len(dataset)), len(dataset)))
+    if args.max_eval_samples > 0:
+        if isinstance(dataset, IterableDataset):
+            dataset = dataset.take(int(args.max_eval_samples))
+        else:
+            dataset = dataset.select(range(min(int(args.max_eval_samples), len(dataset))))
+    return dataset
+
+
+class Audio8Evaluator:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+        self.device = resolve_device(args.device)
+        self.dtype = resolve_dtype(args.dtype, self.device)
+        model_path = Path(args.model_id)
+        revision = None if model_path.exists() else args.model_revision
+        self.processor = AutoProcessor.from_pretrained(
+            args.model_id,
+            revision=revision,
+            trust_remote_code=True,
+            local_files_only=args.local_files_only,
+        )
+        self.processor.tokenizer.padding_side = "left"
+        self.model = AutoModelForCausalLM.from_pretrained(
+            args.model_id,
+            revision=revision,
+            trust_remote_code=True,
+            local_files_only=args.local_files_only,
+            dtype=self.dtype,
+            attn_implementation=args.attn_implementation,
+        ).to(self.device)
+        self.model.eval()
+        self.model_size = sum(parameter.numel() for parameter in self.model.parameters())
+        self.hop_length = int(getattr(self.processor.feature_extractor, "hop_length", 160))
+        self.eos_token_ids = unique_token_ids(
+            [
+                self.processor.tokenizer.eos_token_id,
+                self.processor.tokenizer.convert_tokens_to_ids("<|im_end|>"),
+                getattr(self.model.config, "eos_token_id", None),
+                getattr(self.model.generation_config, "eos_token_id", None),
+            ]
+        )
+        self.generate_kwargs: dict[str, Any] = {
+            "max_new_tokens": int(args.max_new_tokens),
+            "do_sample": False,
+            "use_cache": True,
+        }
+        if args.torch_compile is not None:
+            self.model.generation_config.cache_implementation = "static"
+            self.generate_kwargs["compile_config"] = CompileConfig(
+                mode=args.torch_compile,
+                fullgraph=args.compile_fullgraph,
+            )
+
+    def _prepare_single_input(self, waveform: np.ndarray) -> dict[str, torch.Tensor]:
+        max_samples = int(round(float(self.args.max_audio_seconds) * int(self.args.sampling_rate)))
+        waveform = np.asarray(waveform, dtype=np.float32).reshape(-1)
+        if max_samples > 0:
+            waveform = waveform[:max_samples]
+        return dict(
+            self.processor.apply_chat_template(
+                build_conversation(waveform),
+                return_tensors="pt",
+                sampling_rate=int(self.args.sampling_rate),
+                audio_padding="longest",
+                add_generation_prompt=True,
+                audio_max_length=max_samples,
+                audio_torch_dtype=self.dtype,
+                text_kwargs={
+                    "padding": "longest",
+                    "truncation": True,
+                    "max_length": int(self.args.model_max_length),
+                },
+            )
+        )
+
+    def prepare_batch_inputs(
+        self,
+        waveforms: Sequence[np.ndarray],
+    ) -> tuple[dict[str, torch.Tensor], int]:
+        workers = max(1, min(int(self.args.feature_workers), len(waveforms)))
+        if workers == 1:
+            per_sample_inputs = [self._prepare_single_input(waveform) for waveform in waveforms]
+        else:
+            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="audio8-features") as executor:
+                per_sample_inputs = list(executor.map(self._prepare_single_input, waveforms))
+
+        prompt_length = max(int(item["input_ids"].shape[1]) for item in per_sample_inputs)
+        feature_width = max(int(item["input_features"].shape[-1]) for item in per_sample_inputs)
+        pad_token_id = int(self.processor.tokenizer.pad_token_id)
+        input_ids: list[torch.Tensor] = []
+        attention_masks: list[torch.Tensor] = []
+        input_features: list[torch.Tensor] = []
+        feature_lengths: list[int] = []
+        for item in per_sample_inputs:
+            ids = item["input_ids"][0]
+            attention_mask = item["attention_mask"][0]
+            text_padding = prompt_length - int(ids.shape[0])
+            if text_padding > 0:
+                ids = F.pad(ids, (text_padding, 0), value=pad_token_id)
+                attention_mask = F.pad(attention_mask, (text_padding, 0), value=0)
+            features = item["input_features"][0]
+            valid_feature_width = int(features.shape[-1])
+            feature_padding = feature_width - valid_feature_width
+            if feature_padding > 0:
+                features = F.pad(features, (0, feature_padding), value=0.0)
+            input_ids.append(ids)
+            attention_masks.append(attention_mask)
+            input_features.append(features)
+            feature_lengths.append(valid_feature_width)
+
+        return {
+            "input_ids": torch.stack(input_ids, dim=0),
+            "attention_mask": torch.stack(attention_masks, dim=0),
+            "input_features": torch.stack(input_features, dim=0),
+            "feature_lens": torch.tensor(feature_lengths, dtype=torch.long),
+        }, prompt_length
+
+    def transcribe_batch(self, waveforms: Sequence[np.ndarray]) -> BatchOutput:
+        if not waveforms:
+            return BatchOutput([], [], 0.0, [], [], [])
+        clipped_waveforms = []
+        max_samples = int(round(float(self.args.max_audio_seconds) * int(self.args.sampling_rate)))
+        for waveform in waveforms:
+            waveform = np.asarray(waveform, dtype=np.float32).reshape(-1)
+            clipped_waveforms.append(waveform[:max_samples] if max_samples > 0 else waveform)
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+            start_event = torch.cuda.Event(enable_timing=True)
+            end_event = torch.cuda.Event(enable_timing=True)
+            start_event.record()
+        else:
+            start_time = time.perf_counter()
+
+        inputs, prompt_length = self.prepare_batch_inputs(clipped_waveforms)
+        inputs = {
+            key: value.to(self.device) if torch.is_tensor(value) else value
+            for key, value in dict(inputs).items()
+        }
+
+        with torch.inference_mode():
+            output_ids = self.model.generate(**inputs, **self.generate_kwargs)
+
+        if self.device.type == "cuda":
+            end_event.record()
+            torch.cuda.synchronize(self.device)
+            runtime = start_event.elapsed_time(end_event) / 1000.0
+        else:
+            runtime = time.perf_counter() - start_time
+
+        generated_batch = output_ids[:, prompt_length:].detach().cpu().tolist()
+        eos_set = set(self.eos_token_ids)
+        pad_token_id = self.processor.tokenizer.pad_token_id
+        predictions: list[str] = []
+        visible_batch: list[list[int]] = []
+        stop_hits: list[bool] = []
+        max_new_hits: list[bool] = []
+        stop_token_ids: list[int | None] = []
+        for generated in generated_batch:
+            visible_ids: list[int] = []
+            stop_token_id: int | None = None
+            for token_id in generated:
+                token_id = int(token_id)
+                if token_id in eos_set:
+                    stop_token_id = token_id
+                    break
+                if pad_token_id is not None and token_id == int(pad_token_id):
+                    continue
+                visible_ids.append(token_id)
+            prediction = self.processor.decode(visible_ids, skip_special_tokens=True)
+            predictions.append(normalize_whitespace(prediction))
+            visible_batch.append(visible_ids)
+            stop_hits.append(stop_token_id is not None)
+            max_new_hits.append(stop_token_id is None and len(visible_ids) >= int(self.args.max_new_tokens))
+            stop_token_ids.append(stop_token_id)
+        return BatchOutput(
+            predictions=predictions,
+            generated_ids=visible_batch,
+            runtime_seconds=runtime,
+            stop_hits=stop_hits,
+            max_new_hits=max_new_hits,
+            stop_token_ids=stop_token_ids,
+        )
+
+
+def process_batch(
+    batch: dict[str, list[Any]],
+    evaluator: Audio8Evaluator,
+    args: argparse.Namespace,
+) -> dict[str, list[Any]]:
+    audio_items = batch["audio"]
+    waveforms: list[np.ndarray] = []
+    durations: list[float] = []
+    for audio in audio_items:
+        waveform, sampling_rate = waveform_from_audio_item(audio, args.sampling_rate)
+        waveforms.append(waveform)
+        durations.append(float(len(waveform)) / float(sampling_rate))
+    output = evaluator.transcribe_batch(waveforms)
+    per_sample_time = output.runtime_seconds / len(waveforms)
+    references = list(batch.get("original_text") or [data_utils.get_text(row) for row in batch])
+    audio_filepaths = data_utils.extract_audio_filepaths_from_batch(batch, len(waveforms))
+    result = {
+        "audio_length_s": durations,
+        "transcription_time_s": [per_sample_time] * len(waveforms),
+        "predictions": output.predictions,
+        "references": references,
+        "audio_filepath": audio_filepaths,
+        "generated_tokens": [len(ids) for ids in output.generated_ids],
+        "generation_hit_stop": output.stop_hits,
+        "generation_hit_max_new_tokens": output.max_new_hits,
+        "generation_stop_token_id": output.stop_token_ids,
+    }
+    if data_utils.is_chunked_dataset(args.dataset_path):
+        result.update({key: list(batch[key]) for key in data_utils.CHUNK_METADATA_KEYS})
+    return result
+
+
+@contextmanager
+def working_directory(path: Path) -> Iterator[None]:
+    previous = Path.cwd()
+    path.mkdir(parents=True, exist_ok=True)
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def write_outputs(
+    all_results: dict[str, list[Any]],
+    evaluator: Audio8Evaluator,
+    args: argparse.Namespace,
+) -> tuple[Path, dict[str, Any]]:
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+    output_root = args.output_root.resolve()
+    manifest_model_id = args.manifest_model_id or args.model_id
+    with working_directory(output_root):
+        manifest_relative = data_utils.write_manifest(
+            all_results["references"],
+            all_results["predictions"],
+            manifest_model_id,
+            args.dataset_path,
+            args.dataset,
+            args.split,
+            audio_length=all_results["audio_length_s"],
+            transcription_time=all_results["transcription_time_s"],
+            audio_filepaths=all_results["audio_filepath"],
+            extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+            if is_chunked
+            else None,
+        )
+    manifest_path = output_root / manifest_relative
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        raw_references = [session["text"] for session in sessions]
+        raw_predictions = [session["pred_text"] for session in sessions]
+    else:
+        raw_references = all_results["references"]
+        raw_predictions = all_results["predictions"]
+    references = [data_utils.normalizer(text) for text in raw_references]
+    predictions = [data_utils.normalizer(text) for text in raw_predictions]
+    refs_split = [tuple(text.split()) for text in references]
+    preds_split = [tuple(text.split()) for text in predictions]
+    errors = batch_error_rate(refs_split, preds_split, merge_compounds=True)
+    total_audio = sum(float(value) for value in all_results["audio_length_s"])
+    total_time = sum(float(value) for value in all_results["transcription_time_s"])
+    max_hit_indices = [
+        index
+        for index, hit in enumerate(all_results["generation_hit_max_new_tokens"])
+        if hit
+    ]
+    summary = {
+        "model_id": args.model_id,
+        "manifest_model_id": manifest_model_id,
+        "model_revision": args.model_revision,
+        "dataset_path": args.dataset_path,
+        "dataset": args.dataset,
+        "split": args.split,
+        "manifest": str(manifest_path),
+        "samples": len(all_results["predictions"]),
+        # chunked datasets are scored per parent session, not per sample
+        "scored_units": len(references),
+        "wer": round(100.0 * float(errors["err_rate"]), 4),
+        "ins": int(errors["ins"]),
+        "del": int(errors["del"]),
+        "sub": int(errors["sub"]),
+        "audio_seconds": total_audio,
+        "inference_seconds": total_time,
+        "rtfx": total_audio / total_time if total_time > 0 else None,
+        "stop_hits": sum(bool(value) for value in all_results["generation_hit_stop"]),
+        "max_new_hits": sum(bool(value) for value in all_results["generation_hit_max_new_tokens"]),
+        "empty_predictions": sum(not str(value).strip() for value in all_results["predictions"]),
+        "mean_generated_tokens": (
+            sum(int(value) for value in all_results["generated_tokens"]) / len(all_results["generated_tokens"])
+            if all_results["generated_tokens"]
+            else 0.0
+        ),
+        "max_new_audio_filepaths": [all_results["audio_filepath"][index] for index in max_hit_indices],
+        "model_parameters": evaluator.model_size,
+        "settings": {
+            "device": str(evaluator.device),
+            "dtype": str(evaluator.dtype),
+            "attn_implementation": args.attn_implementation,
+            "batch_size": args.batch_size,
+            "max_new_tokens": args.max_new_tokens,
+            "max_audio_seconds": args.max_audio_seconds,
+            "sampling_rate": args.sampling_rate,
+            "model_max_length": args.model_max_length,
+            "padding_side": evaluator.processor.tokenizer.padding_side,
+            "feature_lengths_supplied": True,
+            "torch_compile": args.torch_compile,
+            "feature_workers": args.feature_workers,
+            "torch_cpu_threads": args.torch_cpu_threads,
+        },
+    }
+    summary_path = manifest_path.with_suffix(manifest_path.suffix + ".summary.json")
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return manifest_path, summary
+
+
+def source_batches(args: argparse.Namespace) -> Iterator[dict[str, list[Any]]]:
+    if parquet_paths(args):
+        for rows in chunked_rows(iter_local_rows(args), max(1, int(args.batch_size))):
+            yield local_batch_from_rows(rows)
+        return
+    dataset = load_official_dataset(args)
+    yield from iter_official_batches(dataset, max(1, int(args.batch_size)))
+
+
+def main() -> None:
+    args = parse_args()
+    if args.batch_size < 1:
+        raise ValueError("--batch_size must be positive")
+    if data_utils.is_chunked_dataset(args.dataset_path) and parquet_paths(args):
+        raise ValueError(
+            "local Parquet input cannot be used with a chunked dataset: the local rows "
+            "carry no chunk metadata to reassemble sessions with."
+        )
+    if args.feature_workers < 1 or args.torch_cpu_threads < 1:
+        raise ValueError("--feature_workers and --torch_cpu_threads must be positive")
+    random.seed(42)
+    np.random.seed(42)
+    torch.manual_seed(42)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(42)
+    torch.set_num_threads(int(args.torch_cpu_threads))
+    torch.set_float32_matmul_precision("high")
+
+    evaluator = Audio8Evaluator(args)
+    print(f"Model size: {evaluator.model_size / 1e9:.6f}B parameters")
+    print(
+        f"model={args.model_id}@{args.model_revision} dataset={args.dataset}/{args.split} "
+        f"device={evaluator.device} dtype={evaluator.dtype} batch_size={args.batch_size} "
+        f"padding_side={evaluator.processor.tokenizer.padding_side} "
+        f"feature_workers={args.feature_workers} torch_cpu_threads={args.torch_cpu_threads}",
+        flush=True,
+    )
+
+    if args.warmup_steps > 0:
+        try:
+            warmup_batch = next(source_batches(args))
+        except StopIteration:
+            warmup_batch = None
+        if warmup_batch is not None:
+            warmup_waveforms = [
+                waveform_from_audio_item(audio, args.sampling_rate)[0]
+                for audio in warmup_batch["audio"]
+            ]
+            for step in range(int(args.warmup_steps)):
+                evaluator.transcribe_batch(warmup_waveforms)
+                print(f"warmup_step={step + 1}/{args.warmup_steps}", flush=True)
+
+    all_results: dict[str, list[Any]] = {
+        "audio_length_s": [],
+        "transcription_time_s": [],
+        "predictions": [],
+        "references": [],
+        "audio_filepath": [],
+        "generated_tokens": [],
+        "generation_hit_stop": [],
+        "generation_hit_max_new_tokens": [],
+        "generation_stop_token_id": [],
+    }
+    if data_utils.is_chunked_dataset(args.dataset_path):
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
+    processed = 0
+    for batch in source_batches(args):
+        result = process_batch(batch, evaluator, args)
+        for key in all_results:
+            all_results[key].extend(result[key])
+        processed += len(result["predictions"])
+        if processed == len(result["predictions"]) or processed % 100 == 0:
+            print(f"processed={processed}", flush=True)
+
+    manifest_path, summary = write_outputs(all_results, evaluator, args)
+    print(f"Results saved at path: {manifest_path}")
+    print(json.dumps(summary, ensure_ascii=False, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/audio8_asr/submit_jobs.sh
+++ b/audio8_asr/submit_jobs.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-audio8-asr}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MODEL_ID="${MODEL_ID:-AutoArk-AI/Audio8-ASR-0.1B}"
@@ -23,9 +23,32 @@ TORCH_COMPILE="${TORCH_COMPILE:-}"
 JOB_TIMEOUT="${JOB_TIMEOUT:-2h}"
 CUDA_ALLOC_CONF="${CUDA_ALLOC_CONF:-expandable_segments:True}"
 
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+  RUN_EVAL_B64=$(base64 -w0 "$script_dir/run_eval.py")
+  LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+  NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "$repo_root" normalizer | base64 -w0)
+  LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
+
+# Datasets: "name split batch_size [dataset_path]"; dataset_path defaults to
+# $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
   "ami_cleaned test ${AMI_BATCH_SIZE:-1152}"
-  "earnings22 test ${EARNINGS22_BATCH_SIZE:-1024}"
+  "earnings22_cleaned_aa_chunked test ${EARNINGS22_BATCH_SIZE:-1024} ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
   "gigaspeech_cleaned test ${GIGASPEECH_BATCH_SIZE:-1408}"
   "librispeech test.clean ${LIBRISPEECH_CLEAN_BATCH_SIZE:-1024}"
   "librispeech test.other ${LIBRISPEECH_OTHER_BATCH_SIZE:-1024}"
@@ -58,8 +81,9 @@ echo "CUDA allocator: $CUDA_ALLOC_CONF"
 
 pids=()
 for config in "${DATASET_CONFIGS[@]}"; do
-  read -r dataset split batch_size <<< "$config"
-  echo "Submitting dataset=${dataset} split=${split} batch_size=${batch_size}"
+  read -r dataset split batch_size dataset_path <<< "$config"
+  dataset_path="${dataset_path:-$DEFAULT_DATASET_PATH}"
+  echo "Submitting dataset_path=${dataset_path} dataset=${dataset} split=${split} batch_size=${batch_size}"
   (
     hf jobs run \
       --flavor "$FLAVOR" \
@@ -72,12 +96,14 @@ for config in "${DATASET_CONFIGS[@]}"; do
       "hf.co/spaces/${SPACE}" \
       bash -c "
         set -euo pipefail
+        ${LOCAL_NORMALIZER_INJECT}
+        ${LOCAL_SCRIPT_INJECT}
         cd /app
         rm -rf /app/results
         PYTHONPATH=/app python /app/run_eval.py \\
           --model_id=${MODEL_ID} \\
           --model_revision=${MODEL_REVISION} \\
-          --dataset_path=${DATASET_PATH} \\
+          --dataset_path=${dataset_path} \\
           --dataset=${dataset} \\
           --split=${split} \\
           --device=0 \\
@@ -119,7 +145,6 @@ fi
 # Allow the completed Jobs' bucket writes to become visible before syncing.
 sleep 10
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 local_results="$repo_root/results/$MODEL_FOLDER"
 mkdir -p "$local_results"
 hf buckets sync \

--- a/espnet/run_eval.py
+++ b/espnet/run_eval.py
@@ -83,6 +83,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -90,6 +92,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -106,11 +110,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/espnet/submit_jobs.sh
+++ b/espnet/submit_jobs.sh
@@ -5,23 +5,45 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-espnet}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
     "espnet/owsm_ctc_v4_1B 64"
-    "espnet/owsm_ctc_v3.1_1B 64"
-    "espnet/owsm_ctc_v3.2_ft_1B 64"
+    # "espnet/owsm_ctc_v3.1_1B 64"
+    # "espnet/owsm_ctc_v3.2_ft_1B 64"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -37,9 +59,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/granite/run_eval_nar.py
+++ b/granite/run_eval_nar.py
@@ -1,55 +1,77 @@
-import json
 import argparse
 import os
+
+# Disable strict type validation in huggingface_hub (model config has int where float expected)
+os.environ["HF_HUB_DISABLE_STRICT_FIELD_VALIDATION"] = "1"
+
 import torch
-from datasets import load_dataset
-from hojo_asr import HOJO_ASR
 import evaluate
+from datasets import IterableDataset
 from normalizer import data_utils
 import time
 from tqdm import tqdm
 
+from transformers import AutoModel, AutoProcessor
+
 wer_metric = evaluate.load("wer")
+torch.set_float32_matmul_precision('high')
+
 
 def main(args):
-    # Load hojo model
-    model = HOJO_ASR.load_model(args.model_id, device=args.device)
+    # Load model (NLENARDecoder requires flash_attention_2, no fallback possible)
+    device = f"cuda:{args.device}" if args.device != -1 else "cpu"
+    model = AutoModel.from_pretrained(args.model_id, trust_remote_code=True,
+                                      revision=args.revision,
+                                      attn_implementation="flash_attention_2",
+                                      device_map=device, dtype=torch.bfloat16).eval()
     print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
+    processor = AutoProcessor.from_pretrained(args.model_id, trust_remote_code=True,
+                                              revision=args.revision)
 
-    dataset = data_utils.load_data(args)
-    dataset = data_utils.prepare_data(dataset)
-
-    def benchmark(batch):
+    def benchmark(batch, min_new_tokens=None):
         # Load audio inputs
-        audios = [audio["array"] for audio in batch["audio"]] 
-        batch["audio_length_s"] = [len(audio) / batch["audio"][0]["sampling_rate"] for audio in audios]
+        audios = [torch.tensor(audio["array"], device=device).squeeze(0) for audio in batch["audio"]]
         minibatch_size = len(audios)
+        batch["audio_length_s"] = [len(audio["array"]) / audio["sampling_rate"] for audio in batch["audio"]]
         batch["audio_filepath"] = data_utils.extract_audio_filepaths_from_batch(batch, minibatch_size)
-
         # START TIMING
-        torch.cuda.synchronize(device=args.device)
-        start_event = torch.cuda.Event(enable_timing=True)
-        end_event = torch.cuda.Event(enable_timing=True)
-        start_event.record()
-
-        results = model.run_infer(audios, batch_size=args.batch_size)
-
-        # Extract text predictions
-        pred_text = [val["text"] for val in results]
-
+        start_time = time.time()
+        inputs = processor(audios, device=device)
+        # Model Inference
+        with torch.inference_mode():
+            output = model.transcribe(**inputs)
+            output_text = processor.batch_decode(output.preds)
         # END TIMING
-        end_event.record()
-        torch.cuda.synchronize(device=args.device)
-        runtime = start_event.elapsed_time(end_event) / 1000.0
-
+        runtime = time.time() - start_time
         # normalize by minibatch size since we want the per-sample time
         batch["transcription_time_s"] = minibatch_size * [runtime / minibatch_size]
-
-        # normalize transcriptions with English normalizer
-        batch["predictions"] = pred_text  # raw; normalization applied at scoring time
+        batch["predictions"] = output_text  # raw; normalization applied at scoring time
         batch["references"] = batch["original_text"]  # raw; normalization applied at scoring time
-
         return batch
+
+    if args.warmup_steps is not None:
+        dataset = data_utils.load_data(args)
+        dataset = data_utils.prepare_data(dataset)
+
+        num_warmup_samples = args.warmup_steps * args.batch_size
+        # NOTE (ebezzam) chunked datasets are always map-style, regardless of --streaming
+        if isinstance(dataset, IterableDataset):
+            warmup_dataset = dataset.take(num_warmup_samples)
+        else:
+            warmup_dataset = dataset.select(range(min(num_warmup_samples, len(dataset))))
+        warmup_dataset = iter(warmup_dataset.map(benchmark, batch_size=args.batch_size, batched=True))
+
+        for _ in tqdm(warmup_dataset, desc="Warming up..."):
+            continue
+
+    dataset = data_utils.load_data(args)
+    if args.max_eval_samples is not None and args.max_eval_samples > 0:
+        print(f"Subsampling dataset to first {args.max_eval_samples} samples!")
+        if isinstance(dataset, IterableDataset):
+            dataset = dataset.take(args.max_eval_samples)
+        else:
+            dataset = dataset.select(range(min(args.max_eval_samples, len(dataset))))
+    dataset = data_utils.prepare_data(dataset)
 
     dataset = dataset.map(
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
@@ -102,7 +124,6 @@ def main(args):
         references=norm_refs, predictions=norm_preds
     )
     wer = round(100 * wer, 2)
-
     rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
     print("WER:", wer, "%", "RTFx:", rtfx)
 
@@ -113,21 +134,21 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model_id",
         type=str,
-        required=True,
-        help="Model identifier. Should be loadable with qwen_asr",
+        default="ibm-granite/granite-speech-4.1-2b-nar",
+        help="HuggingFace model ID",
     )
     parser.add_argument(
         "--dataset_path",
         type=str,
-        default="hf-audio/open-asr-leaderboard",
-        help="Dataset path. By default, it is `hf-audio/open-asr-leaderboard`",
+        default="esb/datasets",
+        help="Dataset path. By default, it is `esb/datasets`",
     )
     parser.add_argument(
         "--dataset",
         type=str,
         required=True,
         help="Dataset name. *E.g.* `'librispeech_asr` for the LibriSpeech ASR dataset, or `'common_voice'` for Common Voice. The full list of dataset names "
-        "can be found at `https://huggingface.co/datasets/hf-audio/open-asr-leaderboard`",
+        "can be found at `https://huggingface.co/datasets/esb/datasets`",
     )
     parser.add_argument(
         "--split",
@@ -154,15 +175,22 @@ if __name__ == "__main__":
         help="Number of samples to be evaluated. Put a lower number e.g. 64 for testing this script.",
     )
     parser.add_argument(
-        "--streaming",
-        action="store_true",
-        help="Stream the dataset lazily over the network instead of downloading it in full before the evaluation. Off by default for reproducible benchmark timings.",
+        "--no-streaming",
+        dest="streaming",
+        action="store_false",
+        help="Choose whether you'd like to download the entire dataset or stream it during the evaluation.",
     )
     parser.add_argument(
-        "--max_new_tokens",
+        "--warmup_steps",
         type=int,
-        default=256,
-        help="Maximum number of tokens to generate.",
+        default=2,
+        help="Number of warm-up steps to run before launching the timed runs.",
+    )
+    parser.add_argument(
+        "--revision",
+        type=str,
+        default="99a4df9007ac5682f9daa093fb7008ff606e9a5d",
+        help="Model revision (commit hash or branch) to pin remote code and weights.",
     )
 
     args = parser.parse_args()

--- a/granite/run_eval_speculative_bpe.py
+++ b/granite/run_eval_speculative_bpe.py
@@ -1,34 +1,80 @@
 """
-Self-speculative decoding for Speech LLMs.
+Cascade ASR BPE: Self-speculative decoding with dual-head CTC BPE encoder.
+Based on v32 - replaces grapheme CTC draft with BPE CTC draft.
+
+The full Granite Speech encoder already has grapheme out/out_mid heads; only out_llm
+(BPE linear head) needs to be loaded separately from the dual-head encoder safetensors.
+
+Single encoder pass: embeddings from the CTC draft step are reused for verify/fallback.
+Importance for posterior_weighted_pool uses mid-layer (layer num_layers//2) grapheme
+blank probability, captured via a forward hook on the encoder.
 """
 
 import argparse
 import math
 import os
 import torch
+import torch.nn as nn
 import torch.nn.functional as F
 import evaluate
 from normalizer import data_utils
 import time
 from tqdm import tqdm
 from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, models
+from safetensors.torch import load_file
+from huggingface_hub import hf_hub_download
 
 assert hasattr(models, "granite_speech")
 
 wer_metric = evaluate.load("wer")
 torch.set_float32_matmul_precision('high')
 
+LLM_DOWNSAMPLE_WINDOW = 4
+LLM_OUT_DIM = 100353  # 100352 Granite BPE tokens + 1 CTC blank (label 0)
+
+
+def posterior_weighted_pool(hidden, importance, window_size=4):
+    """Importance-weighted downsampling. importance[b,t] = 1 - blank_prob."""
+    B, T, D = hidden.shape
+    pad_len = (window_size - T % window_size) % window_size
+    if pad_len > 0:
+        hidden = F.pad(hidden, (0, 0, 0, pad_len))
+        importance = F.pad(importance, (0, pad_len))
+    num_windows = hidden.shape[1] // window_size
+    hidden = hidden.view(B, num_windows, window_size, D)
+    importance = importance.view(B, num_windows, window_size)
+    weights = importance / (importance.sum(dim=-1, keepdim=True) + 1e-8)
+    return (hidden * weights.unsqueeze(-1)).sum(dim=2), window_size
+
 
 def main(args):
     device = f"cuda:{args.device}" if args.device >= 0 else "cpu"
 
+    # Full Granite Speech model
     processor = AutoProcessor.from_pretrained(args.model_id)
     tokenizer = processor.tokenizer
     model = AutoModelForSpeechSeq2Seq.from_pretrained(args.model_id, torch_dtype=torch.bfloat16).to(device)
     model.eval()
     print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
-
     logits_scaling = getattr(model.language_model.config, 'logits_scaling', 1.0)
+
+    # BPE CTC head (loaded separately, plugs on top of model.encoder)
+    out_llm = nn.Linear(model.encoder.config.hidden_dim, LLM_OUT_DIM, bias=True)
+    llm_weights = load_file(hf_hub_download(repo_id=args.model_id, filename="out_llm.safetensors"))
+    out_llm.load_state_dict(llm_weights)
+    out_llm.to(torch.bfloat16).eval().to(device)
+
+    # Forward hook to capture mid-layer hidden state for importance weighting.
+    # The dual-head encoder applies grapheme feedback at layer num_layers//2; we hook
+    # the output of that layer (before feedback addition) to compute blank probability.
+    num_enc_layers = model.encoder.config.num_layers
+    mid_layer_idx = num_enc_layers // 2 - 1  # 0-based index into model.encoder.layers
+    _mid_hidden = {}
+
+    def _save_mid_hidden(module, input, output):
+        _mid_hidden['h'] = output[0] if isinstance(output, tuple) else output
+
+    _hook = model.encoder.layers[mid_layer_idx].register_forward_hook(_save_mid_hidden)
 
     # ========== Chat Template Setup ==========
     text_instruction = "<|audio|>can you transcribe the speech into a written format?"
@@ -54,33 +100,72 @@ def main(args):
     ctc_threshold = args.ctc_threshold
 
     @torch.no_grad()
-    def ctc_decode(audios):
-        """CTC decode with entropy-based confidence."""
+    def ctc_decode_bpe(audios):
+        """BPE CTC draft: single encoder pass, reuse embeddings for verify/fallback."""
         texts = [text_prompt] * len(audios)
         model_inputs = processor(texts, audios, device=device, return_tensors="pt").to(device)
 
         with torch.amp.autocast(device_type='cuda', dtype=torch.bfloat16):
             encoder_output = model.encoder(model_inputs["input_features"])
-            embeddings = encoder_output.last_hidden_state if hasattr(encoder_output, 'last_hidden_state') else encoder_output
-            ctc_logits = model.encoder.out(embeddings)
-            ctc_probs = F.softmax(ctc_logits.float(), dim=-1)
+            # Full-resolution encoder hidden states — passed unchanged to model.projector
+            # for LLM verification and fallback; never modified by posterior_weighted_pool.
+            enc_hidden = encoder_output.last_hidden_state if hasattr(encoder_output, 'last_hidden_state') else encoder_output
 
-        _, idx_batch = ctc_probs.max(dim=-1)
-        entropy = -(ctc_probs * torch.log(ctc_probs + 1e-10)).sum(dim=-1)
+            # Mid-layer hidden state captured by hook; compute grapheme logits for importance
+            mid_h = _mid_hidden['h']
+            mid_grapheme_logits = model.encoder.out(mid_h)
+            grapheme_probs_mid = F.softmax(mid_grapheme_logits.float(), dim=-1)
+            importance = 1.0 - grapheme_probs_mid[:, :, 0]  # 1 - blank_prob
 
-        ctc_texts, ctc_entropies, embed_lengths = [], [], []
-        for i, idx in enumerate(idx_batch):
+            # Pool enc_hidden 4x for BPE CTC head only; enc_hidden itself is not subsampled
+            x_pooled, _ = posterior_weighted_pool(enc_hidden, importance, window_size=LLM_DOWNSAMPLE_WINDOW)
+
+            # Compute per-sample valid pooled lengths
+            # After pooling, T_pooled = ceil((T_enc + pad) / window_size)
+            # Valid frames for sample i: ceil(enc_len_i / window_size)
+            pooled_lengths = []
+            for i in range(len(audios)):
+                enc_len = len(audios[i]) // HOP_LENGTH // 2 + 1
+                enc_len = min(enc_len, enc_hidden.shape[1])
+                pooled_len = math.ceil(enc_len / LLM_DOWNSAMPLE_WINDOW)
+                pooled_lengths.append(min(pooled_len, x_pooled.shape[1]))
+
+            # Gather non-padded positions and apply BPE head
+            valid_positions = []
+            for i, plen in enumerate(pooled_lengths):
+                for t in range(plen):
+                    valid_positions.append((i, t))
+
+            batch_idx = torch.tensor([p[0] for p in valid_positions], device=device)
+            time_idx = torch.tensor([p[1] for p in valid_positions], device=device)
+            x_valid = x_pooled[batch_idx, time_idx, :]  # [N_valid, D]
+            bpe_logits_valid = out_llm(x_valid)  # [N_valid, LLM_OUT_DIM]
+            bpe_probs_valid = F.softmax(bpe_logits_valid.float(), dim=-1)  # [N_valid, V]
+
+        # Decode each sample from its slice of valid probs
+        bpe_texts, bpe_entropies, embed_lengths = [], [], []
+        offset = 0
+        for i in range(len(audios)):
+            plen = pooled_lengths[i]
+            probs_i = bpe_probs_valid[offset:offset + plen]  # [plen, V]
+            offset += plen
+
+            _, idx = probs_i.max(dim=-1)
+            entropy_i = -(probs_i * torch.log(probs_i + 1e-10)).sum(dim=-1)
+
             dedup = torch.unique_consecutive(idx, dim=-1)
-            non_blank = dedup[dedup > 0].tolist()
-            ctc_texts.append(''.join(chr(c) for c in non_blank))
-            ctc_entropies.append(entropy[i].max().item() if non_blank else float('inf'))
+            non_blank = dedup[dedup > 0]
+            token_ids = [t.item() - 1 for t in non_blank]  # label i -> Granite token (i-1)
+            text = tokenizer.decode(token_ids) if token_ids else ""
+            bpe_texts.append(text)
+            bpe_entropies.append(entropy_i.max().item() if token_ids else float('inf'))
             embed_lengths.append(len(audios[i]) // HOP_LENGTH // 2 + 1)
 
-        return ctc_texts, ctc_entropies, embeddings, embed_lengths
+        return bpe_texts, bpe_entropies, enc_hidden, embed_lengths
 
     @torch.no_grad()
     def verify(ctc_texts, embeddings, embed_lengths):
-        """Verify CTC outputs with LLM."""
+        """Verify BPE draft tokens with LLM. Identical to v32 except inputs are already BPE text."""
         batch_sz = len(ctc_texts)
 
         ctc_token_ids = []
@@ -190,7 +275,7 @@ def main(args):
             inputs_embeds=padded, attention_mask=attn_mask,
             bos_token_id=tokenizer.bos_token_id, pad_token_id=tokenizer.pad_token_id,
             eos_token_id=tokenizer.eos_token_id, max_new_tokens=args.max_new_tokens,
-            num_beams=args.num_beams, early_stopping=args.num_beams > 1,
+            num_beams=args.num_beams, early_stopping=True,
             do_sample=False, use_cache=True
         )
 
@@ -205,26 +290,26 @@ def main(args):
 
         start_time = time.time()
 
-        # Step 1: CTC decode
-        ctc_texts, ctc_entropies, embeddings, embed_lengths = ctc_decode(audios)
+        # Step 1: BPE CTC draft (single encoder pass; embeddings reused below)
+        bpe_texts, bpe_entropies, embeddings, embed_lengths = ctc_decode_bpe(audios)
 
-        # Step 2: Gate by CTC entropy
+        # Step 2: Gate by BPE CTC entropy
         predictions = [None] * batch_sz
         verify_idx = []
 
-        for i, (text, ent) in enumerate(zip(ctc_texts, ctc_entropies)):
+        for i, (text, ent) in enumerate(zip(bpe_texts, bpe_entropies)):
             if ent <= ctc_threshold and text.strip():
                 predictions[i] = text.strip()
             else:
                 verify_idx.append(i)
 
-        # Step 3: Verify remaining
+        # Step 3: Verify remaining with LLM (reuses encoder embeddings from step 1)
         if verify_idx:
             verify_emb = embeddings[verify_idx]
-            verify_lens = [embed_lengths[i] for i in verify_idx]
-            verify_texts = [ctc_texts[i] for i in verify_idx]
+            verify_embed_lengths = [embed_lengths[i] for i in verify_idx]
+            verify_bpe_texts = [bpe_texts[i] for i in verify_idx]
 
-            results, audio_embeds, proj_lengths = verify(verify_texts, verify_emb, verify_lens)
+            results, audio_embeds, proj_lengths = verify(verify_bpe_texts, verify_emb, verify_embed_lengths)
 
             fail_idx = []
             for j, (accepted, text) in enumerate(results):
@@ -265,6 +350,8 @@ def main(args):
         for key in all_results:
             all_results[key].append(result[key])
 
+    _hook.remove()  # clean up forward hook
+
     # Write results
     manifest_path = data_utils.write_manifest(
         all_results["references"], all_results["predictions"], args.model_id,
@@ -289,13 +376,14 @@ def main(args):
     norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = round(100 * wer_metric.compute(references=norm_refs, predictions=norm_preds), 2)
     rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)
-    print(f"WER: {wer}%, RTFx: {rtfx}")
+    print(f"{args.model_id} - WER: {wer}%, RTFx: {rtfx}")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model_id", type=str, required=True)
-    parser.add_argument("--dataset_path", type=str, default="hf-audio/open-asr-leaderboard")
+    parser.add_argument("--model_id", type=str, required=True,
+                        help="Full Granite Speech model (provides encoder, projector, LLM)")
+    parser.add_argument("--dataset_path", type=str, default="esb/datasets")
     parser.add_argument("--dataset", type=str, required=True)
     parser.add_argument("--split", type=str, default="test")
     parser.add_argument("--device", type=int, default=-1)
@@ -303,8 +391,9 @@ if __name__ == "__main__":
     parser.add_argument("--max_eval_samples", type=int, default=None)
     parser.add_argument("--max_new_tokens", type=int, default=200)
     parser.add_argument("--num_beams", type=int, default=1)
-    parser.add_argument("--confidence_threshold", type=float, default=0.01)
-    parser.add_argument("--ctc_threshold", type=float, default=0.5)
-    parser.add_argument("--streaming", action="store_true", help="Stream the dataset lazily over the network instead of downloading it in full before the evaluation.")
+    parser.add_argument("--confidence_threshold", type=float, default=0.2)
+    parser.add_argument("--ctc_threshold", type=float, default=0.7)
+    parser.add_argument("--no-streaming", dest="streaming", action="store_false")
     args = parser.parse_args()
+    args.streaming = False
     main(args)

--- a/granite/submit_jobs.sh
+++ b/granite/submit_jobs.sh
@@ -5,9 +5,26 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-granite}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local eval script instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+# The script is picked per model type below, so the injection is built there.
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id type batch_size [additional_params]" ────────────────────
 # Types: speculative, speculative_bpe, nar
@@ -16,12 +33,13 @@ MODEL_CONFIGS=(
     "ibm-granite/granite-speech-4.1-2b speculative_bpe 128"
 )
 
-# ── Datasets: "name split" ───────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -37,9 +55,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} type=${MODEL_TYPE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} type=${MODEL_TYPE}"
 
         # Build command based on model type
         if [[ "$MODEL_TYPE" == "speculative" ]]; then
@@ -56,6 +75,12 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             exit 1
         fi
 
+        LOCAL_SCRIPT_INJECT=""
+        if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+            RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/${EVAL_SCRIPT}")
+            LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/${EVAL_SCRIPT} &&"
+        fi
+
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
 
@@ -69,6 +94,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python ${EVAL_SCRIPT} \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -105,7 +132,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/granite/submit_jobs_nar.sh
+++ b/granite/submit_jobs_nar.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-granite-nar}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 REVISION="99a4df9007ac5682f9daa093fb7008ff606e9a5d"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval_nar.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval_nar.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval_nar.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
     "ibm-granite/granite-speech-4.1-2b-nar"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 512"
     "gigaspeech_cleaned test 512"
     "voxpopuli_cleaned_aa test 256"
-    "earnings22 test 256"
+    "earnings22_cleaned_aa_chunked test 256 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 512"
     "librispeech test.other 512"
     "spgispeech test 512"
@@ -35,9 +57,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval_nar.py \
                     --model_id=${MODEL_ID} \
                     --revision=${REVISION} \
@@ -89,7 +114,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/higgs_audio/run_eval_higgs_audio.py
+++ b/higgs_audio/run_eval_higgs_audio.py
@@ -18,6 +18,7 @@ import runpy
 
 import torch
 import evaluate
+from datasets import IterableDataset
 from normalizer import data_utils
 from transformers import AutoModel, AutoTokenizer
 from tqdm import tqdm
@@ -109,7 +110,8 @@ def main(args):
         warmup_dataset = data_utils.prepare_data(warmup_dataset)
 
         num_warmup_samples = args.warmup_steps * args.batch_size
-        if args.streaming:
+        # NOTE (ebezzam) chunked datasets are always map-style, regardless of --streaming
+        if isinstance(warmup_dataset, IterableDataset):
             warmup_dataset = warmup_dataset.take(num_warmup_samples)
         else:
             warmup_dataset = warmup_dataset.select(
@@ -127,7 +129,7 @@ def main(args):
 
     if args.max_eval_samples is not None and args.max_eval_samples > 0:
         print(f"Subsampling dataset to first {args.max_eval_samples} samples!")
-        if args.streaming:
+        if isinstance(dataset, IterableDataset):
             dataset = dataset.take(args.max_eval_samples)
         else:
             dataset = dataset.select(
@@ -139,12 +141,16 @@ def main(args):
         remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
         "predictions": [],
         "references": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -160,12 +166,22 @@ def main(args):
         args.split,
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    wer = wer_metric.compute(
-        references=all_results["references"], predictions=all_results["predictions"]
-    )
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    # transcripts are already normalized above
+    wer = wer_metric.compute(references=references, predictions=predictions)
     wer = round(100 * wer, 2)
     rtfx = round(
         sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2

--- a/higgs_audio/submit_jobs.sh
+++ b/higgs_audio/submit_jobs.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-boson}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval_higgs_audio.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval_higgs_audio.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -15,12 +36,13 @@ MODEL_CONFIGS=(
     "bosonai/higgs-audio-v3-stt        32"
 )
 
-# ── Datasets: "name split" ───────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -36,8 +58,9 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -51,6 +74,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -86,7 +111,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/hojo_asr/submit_jobs.sh
+++ b/hojo_asr/submit_jobs.sh
@@ -5,19 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-hojo-asr}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=256  # matches the official qwen-asr package default
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
 # Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
 # committed to the Space (useful for iterating without pushing to the Space).
 USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LOCAL_SCRIPT_INJECT=""
 if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
-    LOCAL_SCRIPT_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
-    LOCAL_SCRIPT_INJECT="echo '${LOCAL_SCRIPT_B64}' | base64 -d > /app/run_eval.py &&"
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
 fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
@@ -25,12 +36,13 @@ MODEL_CONFIGS=(
     "HojoAI/Hojo-ASR-V1"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 32"
     "gigaspeech_cleaned test 32"
     "voxpopuli_cleaned_aa test 32"
-    "earnings22 test 32"
+    "earnings22_cleaned_aa_chunked test 32 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 32"
     "librispeech test.other 32"
     "spgispeech test 32"
@@ -45,9 +57,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -61,6 +74,7 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
                 ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
@@ -98,7 +112,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/kyutai/run_eval.py
+++ b/kyutai/run_eval.py
@@ -173,6 +173,8 @@ def main(args):
         remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -180,6 +182,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -196,11 +200,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/kyutai/submit_jobs.sh
+++ b/kyutai/submit_jobs.sh
@@ -5,21 +5,43 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-kyutai}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
     "kyutai/stt-2.6b-en 64"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -35,9 +57,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -50,6 +73,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -85,7 +110,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/liteASR/run_eval.py
+++ b/liteASR/run_eval.py
@@ -122,6 +122,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -129,6 +131,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -145,11 +149,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/liteASR/submit_jobs.sh
+++ b/liteASR/submit_jobs.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-lite-whisper}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -17,12 +38,13 @@ MODEL_CONFIGS=(
     # "efficient-speech/lite-whisper-large-v3-turbo-acc"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 128"
     "gigaspeech_cleaned test 128"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 128"
+    "earnings22_cleaned_aa_chunked test 128 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 128"
     "librispeech test.other 128"
     "spgispeech test 128"
@@ -37,9 +59,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/moss-transcribe-diarize/run_eval.py
+++ b/moss-transcribe-diarize/run_eval.py
@@ -450,6 +450,8 @@ def main(args: argparse.Namespace) -> int:
         remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -457,6 +459,8 @@ def main(args: argparse.Namespace) -> int:
         "predictions": [],
         "references": [],
     }
+    if is_chunked:
+        results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     for result in tqdm(iter(dataset), desc="Samples"):
         for key in results:
             results[key].append(result[key])
@@ -476,6 +480,9 @@ def main(args: argparse.Namespace) -> int:
         audio_length=results["audio_length_s"],
         transcription_time=results["transcription_time_s"],
         audio_filepaths=results["audio_filepath"],
+        extra_fields={key: results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Manifest:", manifest, flush=True)
 

--- a/moss-transcribe-diarize/submit_jobs.sh
+++ b/moss-transcribe-diarize/submit_jobs.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-moss-transcribe-diarize}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MODEL_ID="${MODEL_ID:-OpenMOSS-Team/MOSS-Transcribe-Diarize}"
@@ -15,9 +15,11 @@ WARMUP_STEPS="${WARMUP_STEPS:-1}"
 BATCH_SIZE="${BATCH_SIZE:-256}"
 JOB_TIMEOUT="${JOB_TIMEOUT:-8h}"
 
+# Datasets: "name split [dataset_path]"; dataset_path defaults to
+# $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned test"
     "librispeech test.clean"
     "librispeech test.other"
@@ -59,8 +61,9 @@ fi
 
 pids=()
 for config in "${DATASET_CONFIGS[@]}"; do
-    read -r dataset split <<< "${config}"
-    echo "Submitting model=${MODEL_ID} dataset=${dataset} split=${split} batch_size=${BATCH_SIZE}"
+    read -r dataset split dataset_path <<< "${config}"
+    dataset_path="${dataset_path:-$DEFAULT_DATASET_PATH}"
+    echo "Submitting model=${MODEL_ID} dataset_path=${dataset_path} dataset=${dataset} split=${split} batch_size=${BATCH_SIZE}"
 
     (
         hf jobs run \
@@ -78,7 +81,7 @@ for config in "${DATASET_CONFIGS[@]}"; do
                 PYTHONPATH=/app python run_eval.py \
                     --model_id='${MODEL_ID}' \
                     --model_revision='${MODEL_REVISION}' \
-                    --dataset_path='${DATASET_PATH}' \
+                    --dataset_path='${dataset_path}' \
                     --dataset='${dataset}' \
                     --split='${split}' \
                     --device=0 \

--- a/moss-transcribe/run_eval.py
+++ b/moss-transcribe/run_eval.py
@@ -1,0 +1,229 @@
+"""
+Open ASR Leaderboard entry: MOSS-Transcribe-preview-2B.
+
+Pipeline:
+  - librosa.load @ 16 kHz
+  - WhisperFeatureExtractor log-mel (n_fft=400, hop=160, dim=128)
+  - MossProcessor with a single default chat template (identical across all
+    datasets, no per-dataset style switching)
+  - MossForCausalLM.generate(greedy, num_beams=1, eos=processor.end_token_id)
+"""
+import argparse
+import os
+
+import librosa
+import numpy as np
+import torch
+from tqdm import tqdm
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    BatchEncoding,
+)
+from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from transformers.models.whisper.feature_extraction_whisper import WhisperFeatureExtractor
+
+import evaluate
+from normalizer import data_utils
+
+wer_metric = evaluate.load("wer")
+
+SAMPLE_RATE = 16000
+MEL_DIM = 128
+N_FFT = 400
+HOP = 160
+
+
+def build_processor(model_id, tokenizer, revision=None):
+    """Reproduce WhisperLogMelMossProcessor.__call__ behavior."""
+    MossProcessor = get_class_from_dynamic_module(
+        "processing_Moss.MossProcessor", model_id, revision=revision
+    )
+    MelConfig = get_class_from_dynamic_module(
+        "processing_Moss.MelConfig", model_id, revision=revision
+    )
+    mel_cfg = MelConfig(mel_sr=SAMPLE_RATE, mel_dim=MEL_DIM, mel_n_fft=N_FFT, mel_hop_length=HOP)
+    processor = MossProcessor(tokenizer, config=mel_cfg, enable_time_marker=False)
+    template_path = os.path.join(os.path.dirname(__file__), "chat_template_default.py")
+    processor.load_template(template_path)
+
+    fe = WhisperFeatureExtractor(
+        feature_size=MEL_DIM, sampling_rate=SAMPLE_RATE, hop_length=HOP, n_fft=N_FFT
+    )
+    return processor, fe
+
+
+def encode_one(audio_np: np.ndarray, processor, fe):
+    """Single-sample encode: returns (input_ids[L], audio_mask[L], mel[128,T], T)."""
+    wav = audio_np.astype(np.float32)
+    try:
+        mel = fe._np_extract_fbank_features(wav[None, ...], device="cpu")[0]
+    except TypeError:
+        mel = fe._np_extract_fbank_features(wav[None, ...])[0]
+    mel = torch.from_numpy(mel).to(processor.config.mel_dtype)
+    if mel.dim() == 3:
+        mel = mel.squeeze(0)
+
+    T = mel.shape[-1]
+    num_audio_tokens = processor._get_feat_extract_output_lengths(T)
+    if processor.chat_template is not None:
+        ids, mask = processor._build_input_from_template(num_audio_tokens)
+    else:
+        ids, mask = processor._build_input_legacy(num_audio_tokens)
+    return ids, mask, mel, T
+
+
+def encode_batch(audios, processor, fe, device, model_dtype) -> BatchEncoding:
+    """Concat mel along time dim, left-pad input_ids per sample for batched generate."""
+    encs = [encode_one(a, processor, fe) for a in audios]
+    L = max(len(e[0]) for e in encs)
+    bs = len(encs)
+    pad_id = processor.tokenizer.pad_token_id or processor.end_token_id
+
+    input_ids = torch.full((bs, L), pad_id, dtype=torch.long)
+    attn_mask = torch.zeros((bs, L), dtype=torch.long)
+    audio_mask = torch.zeros((bs, L), dtype=torch.bool)
+    seq_lens = torch.zeros((bs,), dtype=torch.long)
+    mel_parts = []
+    for i, (ids, m, mel, T) in enumerate(encs):
+        li = len(ids)
+        input_ids[i, -li:]  = torch.tensor(ids, dtype=torch.long)
+        attn_mask[i, -li:]  = 1
+        audio_mask[i, -li:] = torch.tensor(m, dtype=torch.bool)
+        seq_lens[i] = T
+        mel_parts.append(mel)
+    audio_data = torch.cat(mel_parts, dim=-1)
+
+    return BatchEncoding(data={
+        "input_ids": input_ids.to(device),
+        "attention_mask": attn_mask.to(device),
+        "audio_data": audio_data.to(device).to(model_dtype),
+        "audio_data_seqlens": seq_lens.to(device),
+        "audio_input_mask": audio_mask.to(device),
+    })
+
+
+def main(args):
+    device = f"cuda:{args.device}" if args.device >= 0 else "cpu"
+
+    model = AutoModelForCausalLM.from_pretrained(
+        args.model_id, dtype="auto", trust_remote_code=True, revision=args.model_revision
+    ).to(device)
+    model.eval()
+    print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.model_id, trust_remote_code=True, revision=args.model_revision
+    )
+    processor, fe = build_processor(args.model_id, tokenizer, revision=args.model_revision)
+    eos_ids = [processor.end_token_id]
+
+    def benchmark(batch):
+        # Open ASR Leaderboard hands us audio dicts at 16 kHz already; resample defensively.
+        sr_in = batch["audio"][0]["sampling_rate"]
+        audios = []
+        for a in batch["audio"]:
+            wav = a["array"]
+            if sr_in != SAMPLE_RATE:
+                wav = librosa.resample(wav.astype(np.float32), orig_sr=sr_in, target_sr=SAMPLE_RATE)
+            audios.append(wav)
+        batch["audio_length_s"] = [len(w) / SAMPLE_RATE for w in audios]
+        mb = len(audios)
+        batch["audio_filepath"] = data_utils.extract_audio_filepaths_from_batch(batch, mb)
+
+        torch.cuda.synchronize(device=device)
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+
+        inputs = encode_batch(audios, processor, fe, device, model.dtype)
+        with torch.no_grad():
+            gen_ids = model.generate(
+                **inputs,
+                max_new_tokens=args.max_new_tokens,
+                do_sample=False,
+                num_beams=1,
+                use_cache=True,
+                eos_token_id=eos_ids,
+            )
+        new_ids = gen_ids[:, inputs["input_ids"].shape[1]:]
+        preds = [t.strip() for t in processor.batch_decode(new_ids, skip_special_tokens=True)]
+
+        end_event.record()
+        torch.cuda.synchronize(device=device)
+        runtime = start_event.elapsed_time(end_event) / 1000.0
+        batch["transcription_time_s"] = mb * [runtime / mb]
+        # Save raw (unnormalized) outputs; normalization is applied at scoring time.
+        batch["predictions"] = preds
+        batch["references"] = batch["original_text"]
+        return batch
+
+    # ---- Warm-up ----
+    if args.warmup_steps:
+        warmup = data_utils.load_data(args)
+        warmup = data_utils.prepare_data(warmup)
+        n = args.warmup_steps * args.batch_size
+        warmup = warmup.take(n) if args.streaming else warmup.select(range(min(n, len(warmup))))
+        for _ in tqdm(iter(warmup.map(benchmark, batch_size=args.batch_size, batched=True)), desc="Warmup"):
+            pass
+
+    # ---- Eval ----
+    ds = data_utils.load_data(args)
+    ds = data_utils.prepare_data(ds)
+    if args.max_eval_samples and args.max_eval_samples > 0:
+        ds = ds.take(args.max_eval_samples) if args.streaming else ds.select(
+            range(min(args.max_eval_samples, len(ds)))
+        )
+    ds = ds.map(benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"])
+
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
+    res = {"audio_length_s": [], "transcription_time_s": [], "predictions": [], "references": [], "audio_filepath": []}
+    if is_chunked:
+        res.update({k: [] for k in data_utils.CHUNK_METADATA_KEYS})
+    for r in tqdm(iter(ds), desc="Samples"):
+        for k in res:
+            res[k].append(r[k])
+
+    manifest = data_utils.write_manifest(
+        res["references"], res["predictions"], args.model_id,
+        args.dataset_path, args.dataset, args.split,
+        audio_length=res["audio_length_s"], transcription_time=res["transcription_time_s"],
+        audio_filepaths=res["audio_filepath"],
+        extra_fields={k: res[k] for k in data_utils.CHUNK_METADATA_KEYS} if is_chunked else None,
+    )
+    print("Manifest:", os.path.abspath(manifest))
+
+    # Chunked datasets are scored per parent session, not per chunk.
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest))
+        references = [s["text"] for s in sessions]
+        predictions = [s["pred_text"] for s in sessions]
+    else:
+        references = res["references"]
+        predictions = res["predictions"]
+
+    # Normalize raw references/predictions at scoring time.
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
+    wer = round(100 * wer_metric.compute(references=norm_refs, predictions=norm_preds), 2)
+    rtfx = round(sum(res["audio_length_s"]) / sum(res["transcription_time_s"]), 2)
+    print(f"WER: {wer}%  RTFx: {rtfx}")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--model_id", type=str, required=True)
+    p.add_argument("--model_revision", type=str, default="c4b3988677df13c14e79d9db59f356ed761db366",
+                   help="Pin the model repo revision (commit) for trust_remote_code stability.")
+    p.add_argument("--dataset_path", type=str, default="hf-audio/esb-datasets-test-only-sorted")
+    p.add_argument("--dataset", type=str, required=True)
+    p.add_argument("--split", type=str, default="test")
+    p.add_argument("--device", type=int, default=0)
+    p.add_argument("--batch_size", type=int, default=1)
+    p.add_argument("--max_new_tokens", type=int, default=1024)
+    p.add_argument("--max_eval_samples", type=int, default=None)
+    p.add_argument("--streaming", action="store_true", help="Stream the dataset instead of downloading it.")
+    p.add_argument("--warmup_steps", type=int, default=10)
+    args = p.parse_args()
+    main(args)

--- a/moss-transcribe/submit_jobs.sh
+++ b/moss-transcribe/submit_jobs.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-moss-transcribe}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -17,11 +38,12 @@ MODEL_CONFIGS=(
 # Pin the model repo revision for trust_remote_code stability (in case remote code changes).
 MODEL_REVISION="${MODEL_REVISION:-c4b3988677df13c14e79d9db59f356ed761db366}"
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "voxpopuli_cleaned_aa test 128"
     "ami_cleaned test 128"
-    "earnings22 test 128"
+    "earnings22_cleaned_aa_chunked test 128 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned test 128"
     "librispeech test.clean 128"
     "librispeech test.other 128"
@@ -37,9 +59,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --model_revision=${MODEL_REVISION} \
@@ -89,7 +114,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/nemo_asr/run_eval.py
+++ b/nemo_asr/run_eval.py
@@ -44,6 +44,8 @@ def main(args):
     asr_model.eval()
     print(f"Model size: {sum(p.numel() for p in asr_model.parameters()) / 1e9:.2f}B parameters")
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     dataset = data_utils.load_data(args)
 
     if args.max_eval_samples is not None and args.max_eval_samples > 0:
@@ -120,6 +122,8 @@ def main(args):
         "durations": [],
         "references": [],
     }
+    if is_chunked:
+        all_data.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
 
     data_itr = iter(dataset)
     for data in tqdm(data_itr, desc="Downloading Samples"):
@@ -128,10 +132,8 @@ def main(args):
     
     # Sort audio_filepaths and references based on durations values
     sorted_indices = sorted(range(len(all_data["durations"])), key=lambda k: all_data["durations"][k], reverse=True)
-    all_data["audio_filepaths"] = [all_data["audio_filepaths"][i] for i in sorted_indices]
-    all_data["original_audio_filepaths"] = [all_data["original_audio_filepaths"][i] for i in sorted_indices]
-    all_data["references"] = [all_data["references"][i] for i in sorted_indices]
-    all_data["durations"] = [all_data["durations"][i] for i in sorted_indices]
+    for key, values in all_data.items():
+        all_data[key] = [values[i] for i in sorted_indices]
     
     
     total_time = 0
@@ -174,11 +176,23 @@ def main(args):
         audio_length=all_data["durations"],
         transcription_time=[avg_time] * len(all_data["audio_filepaths"]),
         audio_filepaths=all_data["original_audio_filepaths"],
+        extra_fields={key: all_data[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
 
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_references = [data_utils.normalizer(r) for r in all_data['references']]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(
+            data_utils.read_manifest(manifest_path)
+        )
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_data["references"]
+
+    norm_references = [data_utils.normalizer(r) for r in references]
     norm_predictions = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(references=norm_references, predictions=norm_predictions)
     wer = round(100 * wer, 2)

--- a/nemo_asr/run_eval_salm.py
+++ b/nemo_asr/run_eval_salm.py
@@ -92,6 +92,8 @@ def main(args):
     model = SALM.from_pretrained(args.model_id).eval().to(torch.bfloat16).to(device)
     print(f"Model size: {sum(p.numel() for p in model.parameters()) / 1e9:.2f}B parameters")
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     dataset = data_utils.load_data(args)
 
     def download_audio_files(batch):
@@ -161,6 +163,8 @@ def main(args):
         "durations": [],
         "references": [],
     }
+    if is_chunked:
+        all_data.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
 
     data_itr = iter(dataset)
     for data in tqdm(data_itr, desc="Downloading Samples"):
@@ -169,10 +173,8 @@ def main(args):
 
     # Sort audio_filepaths and references based on durations values
     sorted_indices = sorted(range(len(all_data["durations"])), key=lambda k: all_data["durations"][k], reverse=True)
-    all_data["audio_filepaths"] = [all_data["audio_filepaths"][i] for i in sorted_indices]
-    all_data["original_audio_filepaths"] = [all_data["original_audio_filepaths"][i] for i in sorted_indices]
-    all_data["references"] = [all_data["references"][i] for i in sorted_indices]
-    all_data["durations"] = [all_data["durations"][i] for i in sorted_indices]
+    for key, values in all_data.items():
+        all_data[key] = [values[i] for i in sorted_indices]
 
 
     total_time = 0
@@ -207,11 +209,23 @@ def main(args):
         audio_length=all_data["durations"],
         transcription_time=[avg_time] * len(all_data["audio_filepaths"]),
         audio_filepaths=all_data["original_audio_filepaths"],
+        extra_fields={key: all_data[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
 
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_data['references']]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(
+            data_utils.read_manifest(manifest_path)
+        )
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_data["references"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
     norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(references=norm_refs, predictions=norm_preds)
     wer = round(100 * wer, 2)

--- a/nemo_asr/run_parakeet.sh
+++ b/nemo_asr/run_parakeet.sh
@@ -26,7 +26,9 @@ MODEL_IDs=(
     "nvidia/parakeet-tdt_ctc-110m"
 )
 
-# ── Datasets: "name split" (comment / uncomment to select) ──────────────────
+# ── Datasets: "name split [dataset_path]" (comment / uncomment to select) ───
+# dataset_path defaults to hf-audio/open-asr-leaderboard when omitted.
+DEFAULT_DATASET_PATH="hf-audio/open-asr-leaderboard"
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
@@ -35,16 +37,18 @@ DATASET_CONFIGS=(
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
 )
 
 for MODEL_ID in "${MODEL_IDs[@]}"; do
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
         python run_eval.py \
             --model_id=${MODEL_ID} \
-            --dataset_path="hf-audio/open-asr-leaderboard" \
+            --dataset_path="${DATASET_PATH}" \
             --dataset="${DATASET}" \
             --split="${SPLIT}" \
             --device=${DEVICE_ID} \

--- a/nemo_asr/submit_jobs_canary.sh
+++ b/nemo_asr/submit_jobs_canary.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-nemo}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -17,12 +38,13 @@ MODEL_CONFIGS=(
     "nvidia/canary-180m-flash 128"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -38,9 +60,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/nemo_asr/submit_jobs_parakeet.sh
+++ b/nemo_asr/submit_jobs_parakeet.sh
@@ -5,20 +5,41 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-nemo}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 ORG_NAME="${ORG_NAME:-}"
 FLAVOR="${FLAVOR:-h200}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
     "nvidia/parakeet-tdt-0.6b-v3 128"
     "nvidia/parakeet-tdt-0.6b-v2 128"
-    "nvidia/parakeet-tdt-1.1b 128"
     "nvidia/parakeet-rnnt-1.1b 128"
     "nvidia/parakeet-rnnt-0.6b 128"
     "nvidia/parakeet-ctc-1.1b 128"
     "nvidia/parakeet-ctc-0.6b 128"
     "nvidia/parakeet-tdt_ctc-110m 128"
+    # "nvidia/parakeet-tdt-1.1b 128"
     # "nvidia/stt_en_fastconformer_transducer_large 128"
     # "nvidia/stt_en_fastconformer_ctc_large 128"
     # "nvidia/stt_en_conformer_ctc_large 128"
@@ -26,12 +47,13 @@ MODEL_CONFIGS=(
     # "nvidia/stt_en_conformer_ctc_small 128"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -47,9 +69,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -62,6 +85,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -97,7 +122,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/nemo_asr/submit_jobs_salm.sh
+++ b/nemo_asr/submit_jobs_salm.sh
@@ -5,21 +5,43 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-nemo}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval_salm.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval_salm.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval_salm.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
     "nvidia/canary-qwen-2.5b 192"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -35,9 +57,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -52,6 +75,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval_salm.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -87,7 +112,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/normalizer/data_utils.py
+++ b/normalizer/data_utils.py
@@ -1,11 +1,17 @@
-import re
 import os
+import re
 
 import num2words
-from datasets import load_dataset, Audio, IterableDataset
-from normalizer import EnglishTextNormalizer, BasicMultilingualTextNormalizer
+from datasets import Audio, IterableDataset, load_dataset
+from huggingface_hub import snapshot_download
+from normalizer import BasicMultilingualTextNormalizer, EnglishTextNormalizer
 
-from .eval_utils import read_manifest, write_manifest, normalize_compound_pairs
+from .eval_utils import (
+    merge_chunked_manifest,
+    normalize_compound_pairs,
+    read_manifest,
+    write_manifest,
+)
 
 
 def is_target_text_in_range(ref):
@@ -25,12 +31,14 @@ class MultilingualNormalizer(BasicMultilingualTextNormalizer):
     def _normalize_numbers(self, text, lang):
         # Join space-separated thousand groups (e.g. "10 000" -> "10000")
         text = re.sub(r"(\d)\s+(\d{3})\b", r"\1\2", text)
+
         # Convert remaining digit sequences to words
         def _replace(m):
             try:
                 return num2words.num2words(int(m.group()), lang=lang)
             except Exception:
                 return m.group()
+
         return re.sub(r"\d+", _replace, text)
 
     def __call__(self, s, lang=None):
@@ -57,6 +65,7 @@ def get_text(sample):
             ".join{sample.keys()}. Ensure a text column name is present in the dataset."
         )
 
+
 normalizer = EnglishTextNormalizer()
 
 ml_normalizer = MultilingualNormalizer(remove_diacritics=False)
@@ -68,7 +77,65 @@ def normalize(batch):
     return batch
 
 
+# Chunked datasets provide one reference transcript per parent session instead of
+# one per chunk. Maps the chunked dataset repo to the repo holding the transcripts.
+CHUNKED_DATASETS = {
+    "artificialanalysis/earnings22-cleaned-aa-chunked": {
+        "parent_dataset_path": "ArtificialAnalysis/Earnings22-Cleaned-AA",
+        "audio_dir": "audio",
+    },
+}
+
+# Carried into the results manifest so chunks can be reassembled at scoring time.
+CHUNK_METADATA_KEYS = ["parent_id", "chunk_index"]
+
+
+def is_chunked_dataset(dataset_path):
+    return str(dataset_path).lower() in CHUNKED_DATASETS
+
+
+def load_chunked_data(args):
+    """Load a chunked dataset, attaching each chunk's parent transcript as `text`."""
+    config = CHUNKED_DATASETS[str(args.dataset_path).lower()]
+
+    parent_dataset = load_dataset(
+        config["parent_dataset_path"], split=args.split, token=True
+    )
+    parent_text = {sample["id"]: get_text(sample) for sample in parent_dataset}
+
+    dataset = load_dataset(args.dataset_path, split=args.split, token=True)
+
+    # Audio is not referenced by the metadata file, so fetch it separately.
+    audio_root = snapshot_download(
+        repo_id=args.dataset_path,
+        repo_type="dataset",
+        allow_patterns=[f"{config['audio_dir']}/*"],
+    )
+
+    missing = sorted(set(dataset["parent_id"]) - set(parent_text))
+    if missing:
+        raise ValueError(
+            f"No transcript found in {config['parent_dataset_path']} for parent "
+            f"id(s) {missing}. The chunked and parent datasets are out of sync."
+        )
+
+    def attach_audio_and_text(sample):
+        sample["audio"] = os.path.join(
+            audio_root, config["audio_dir"], sample["file_name"]
+        )
+        sample["text"] = parent_text[sample["parent_id"]]
+        return sample
+
+    dataset = dataset.map(attach_audio_and_text, load_from_cache_file=False)
+    dataset = dataset.cast_column("audio", Audio())
+
+    return dataset
+
+
 def load_data(args):
+    if is_chunked_dataset(args.dataset_path):
+        return load_chunked_data(args)
+
     dataset = load_dataset(
         args.dataset_path,
         args.dataset,
@@ -79,12 +146,15 @@ def load_data(args):
 
     return dataset
 
+
 def prepare_data(dataset, sampling_rate=16000):
     # Re-sample and normalize transcriptions
     dataset = dataset.cast_column("audio", Audio(sampling_rate=sampling_rate))
     # NOTE (ebezzam) don't load from cache to account for potential changes in normalization logic
     # IterableDataset (streaming) has no cache, so the kwarg is only needed for Dataset
-    map_kwargs = {} if isinstance(dataset, IterableDataset) else {"load_from_cache_file": False}
+    map_kwargs = (
+        {} if isinstance(dataset, IterableDataset) else {"load_from_cache_file": False}
+    )
     dataset = dataset.map(normalize, **map_kwargs)
     dataset = dataset.filter(is_target_text_in_range, input_columns=["norm_text"])
 
@@ -92,9 +162,9 @@ def prepare_data(dataset, sampling_rate=16000):
 
 
 AUDIO_FILEPATH_METADATA_KEYS = [
-    "id",           # Main: https://huggingface.co/datasets/hf-audio/open-asr-leaderboard
-    "file_name",    # Multilingual: https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-multilingual-datasets
-    "file_name",    # Private
+    "id",  # Main: https://huggingface.co/datasets/hf-audio/open-asr-leaderboard
+    "file_name",  # Multilingual: https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-multilingual-datasets
+    "file_name",  # Private
 ]
 
 

--- a/normalizer/eval_utils.py
+++ b/normalizer/eval_utils.py
@@ -329,10 +329,9 @@ def score_results(
             "public",
             None,  # always printed when public datasets are present
             "model,RTFx,License,Size (B),# Languages,Encoder,Decoder,"
-            "AMI-Cleaned WER,Earnings22 WER,Earnings22-Cleaned-AA-chunked WER,Gigaspeech-Cleaned WER,LS Clean WER,LS Other WER,SPGISpeech WER,Voxpopuli-Cleaned-AA WER",
+            "AMI-Cleaned WER,Earnings22-Cleaned-AA-chunked WER,Gigaspeech-Cleaned WER,LS Clean WER,LS Other WER,SPGISpeech WER,Voxpopuli-Cleaned-AA WER",
             {
                 "ami_cleaned_test": ("AMI-Cleaned WER", None),
-                "earnings22_test": ("Earnings22 WER", None),
                 "earnings22_cleaned_aa_chunked_test": (
                     "Earnings22-Cleaned-AA-chunked WER",
                     None,
@@ -347,9 +346,10 @@ def score_results(
         (
             "extra",
             "_cleaned",
-            "model,AMI WER,Gigaspeech WER,Voxpopuli WER",
+            "model,AMI WER,Earnings22 WER,Gigaspeech WER,Voxpopuli WER",
             {
                 "ami_test": ("AMI WER", None),
+                "earnings22_test": ("Earnings22 WER", None),
                 "gigaspeech_test": ("Gigaspeech WER", None),
                 "voxpopuli_test": ("Voxpopuli WER", None),
             },

--- a/normalizer/eval_utils.py
+++ b/normalizer/eval_utils.py
@@ -1,9 +1,9 @@
-import os
 import glob
 import json
+import os
+from collections import defaultdict
 from difflib import SequenceMatcher
 
-from collections import defaultdict
 from kaldialign import batch_error_rate
 
 
@@ -63,6 +63,7 @@ def write_manifest(
     audio_length: list = None,
     transcription_time: list = None,
     audio_filepaths: list = None,
+    extra_fields: dict = None,
 ):
     """
     Writes a manifest file (jsonl format) and returns the path to the file.
@@ -77,6 +78,8 @@ def write_manifest(
         audio_length: Length of each audio sample in seconds.
         transcription_time: Transcription time of each sample in seconds.
         audio_filepaths: List of file paths for each audio sample.
+        extra_fields: Optional mapping of column name to a per-sample list, written
+            alongside the standard fields.
     Returns:
         Path to the manifest file.
     """
@@ -105,6 +108,13 @@ def write_manifest(
             f"The number of samples in `audio_filepaths` ({len(audio_filepaths)}) "
             f"must match `references` ({len(references)})."
         )
+    extra_fields = extra_fields or {}
+    for field_name, values in extra_fields.items():
+        if len(values) != len(references):
+            raise ValueError(
+                f"The number of samples in `{field_name}` ({len(values)}) "
+                f"must match `references` ({len(references)})."
+            )
 
     audio_length = (
         audio_length if audio_length is not None else len(references) * [None]
@@ -127,8 +137,20 @@ def write_manifest(
     )
 
     with open(manifest_path, "w", encoding="utf-8") as f:
-        for idx, (text, transcript, audio_length, transcription_time, audio_filepath) in enumerate(
-            zip(references, transcriptions, audio_length, transcription_time, audio_filepaths)
+        for idx, (
+            text,
+            transcript,
+            audio_length,
+            transcription_time,
+            audio_filepath,
+        ) in enumerate(
+            zip(
+                references,
+                transcriptions,
+                audio_length,
+                transcription_time,
+                audio_filepaths,
+            )
         ):
             datum = {
                 "audio_filepath": audio_filepath if audio_filepath else f"sample_{idx}",
@@ -136,12 +158,71 @@ def write_manifest(
                 "time": transcription_time,
                 "text": text,
                 "pred_text": transcript,
+                **{name: values[idx] for name, values in extra_fields.items()},
             }
             f.write(f"{json.dumps(datum, ensure_ascii=False)}\n")
     return manifest_path
 
 
-def score_results(directory: str, model_id: str = None, multilingual: bool = False, csv_only: bool = False, language: str = "en", families: list = None):
+CHUNK_PARENT_KEY = "parent_id"
+CHUNK_INDEX_KEY = "chunk_index"
+
+
+def merge_chunked_manifest(manifest: list):
+    """Collapse per-chunk result rows into one row per parent session.
+
+    Chunks are non-overlapping and cover the session in order, so predictions are
+    concatenated by `chunk_index` and scored against the session reference.
+    Durations and times are summed, leaving RTFx unaffected.
+
+    Manifests without a `parent_id` field are returned unchanged.
+    """
+    if not manifest or CHUNK_PARENT_KEY not in manifest[0]:
+        return manifest
+
+    sessions = defaultdict(list)
+    for datum in manifest:
+        sessions[datum[CHUNK_PARENT_KEY]].append(datum)
+
+    def _sum_or_none(values):
+        return sum(values) if all(v is not None for v in values) else None
+
+    merged = []
+    for parent_id in sorted(sessions):
+        chunks = sorted(sessions[parent_id], key=lambda d: d[CHUNK_INDEX_KEY])
+
+        indices = [chunk[CHUNK_INDEX_KEY] for chunk in chunks]
+        if indices != list(range(len(indices))):
+            print(
+                f"WARNING: chunk indices for session {parent_id} are not "
+                f"contiguous from 0 ({indices}); some chunks may be missing, "
+                "which will inflate the deletion count."
+            )
+
+        merged.append(
+            {
+                "audio_filepath": parent_id,
+                "duration": _sum_or_none([chunk["duration"] for chunk in chunks]),
+                "time": _sum_or_none([chunk["time"] for chunk in chunks]),
+                "text": chunks[0]["text"],
+                "pred_text": " ".join(
+                    pred
+                    for chunk in chunks
+                    if (pred := (chunk["pred_text"] or "").strip())
+                ),
+            }
+        )
+    return merged
+
+
+def score_results(
+    directory: str,
+    model_id: str = None,
+    multilingual: bool = False,
+    csv_only: bool = False,
+    language: str = "en",
+    families: list = None,
+):
     """
     Scores all result files in a directory and returns a composite score over all evaluated datasets.
 
@@ -175,7 +256,8 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
         print("Filtering models by id:", model_id)
         model_id = model_id.replace("/", "-")
         result_files = [
-            fp for fp in result_files
+            fp
+            for fp in result_files
             if f"/{model_id}/" in fp or f"MODEL_{model_id}_DATASET_" in fp
         ]
 
@@ -207,13 +289,22 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
             "Scripted-US,Scripted-AU,Scripted-CA,Scripted-IN,"
             "Conversational-US003,Conversational-US004,Conversational-IN",
             {
-                "appen_scripted_filtered__american":                     ("Scripted-US",          "scripted"),
-                "appen_scripted_filtered__australian":                   ("Scripted-AU",          "scripted"),
-                "appen_scripted_filtered__canadian":                     ("Scripted-CA",          "scripted"),
-                "appen_scripted_filtered__indian":                       ("Scripted-IN",          "scripted"),
-                "appen_conversational_segmented_filtered__american_003": ("Conversational-US003", "conversational"),
-                "appen_conversational_segmented_filtered__american_004": ("Conversational-US004", "conversational"),
-                "appen_conversational_segmented_filtered__indian":       ("Conversational-IN",    "conversational"),
+                "appen_scripted_filtered__american": ("Scripted-US", "scripted"),
+                "appen_scripted_filtered__australian": ("Scripted-AU", "scripted"),
+                "appen_scripted_filtered__canadian": ("Scripted-CA", "scripted"),
+                "appen_scripted_filtered__indian": ("Scripted-IN", "scripted"),
+                "appen_conversational_segmented_filtered__american_003": (
+                    "Conversational-US003",
+                    "conversational",
+                ),
+                "appen_conversational_segmented_filtered__american_004": (
+                    "Conversational-US004",
+                    "conversational",
+                ),
+                "appen_conversational_segmented_filtered__indian": (
+                    "Conversational-IN",
+                    "conversational",
+                ),
             },
         ),
         (
@@ -222,26 +313,35 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
             "model,Avg DataOcean WER,Avg Scripted,Avg Conversational,"
             "Scripted-US,Scripted-GB,Conversational-US,Conversational-GB",
             {
-                "dataocean_scripted_filtered__en_US":                  ("Scripted-US",       "scripted"),
-                "dataocean_scripted_filtered__en_GB":                  ("Scripted-GB",       "scripted"),
-                "dataocean_conversational_segmented_filtered__en_US":  ("Conversational-US", "conversational"),
-                "dataocean_conversational_segmented_filtered__en_GB":  ("Conversational-GB", "conversational"),
+                "dataocean_scripted_filtered__en_US": ("Scripted-US", "scripted"),
+                "dataocean_scripted_filtered__en_GB": ("Scripted-GB", "scripted"),
+                "dataocean_conversational_segmented_filtered__en_US": (
+                    "Conversational-US",
+                    "conversational",
+                ),
+                "dataocean_conversational_segmented_filtered__en_GB": (
+                    "Conversational-GB",
+                    "conversational",
+                ),
             },
         ),
         (
             "public",
-            None,   # always printed when public datasets are present
+            None,  # always printed when public datasets are present
             "model,RTFx,License,Size (B),# Languages,Encoder,Decoder,"
-            "AMI-Cleaned WER,Earnings22 WER,Gigaspeech-Cleaned WER,LS Clean WER,LS Other WER,SPGISpeech WER,Voxpopuli-Cleaned-AA WER",
+            "AMI-Cleaned WER,Earnings22 WER,Earnings22-Cleaned-AA-chunked WER,Gigaspeech-Cleaned WER,LS Clean WER,LS Other WER,SPGISpeech WER,Voxpopuli-Cleaned-AA WER",
             {
-                
-                "ami_cleaned_test":          ("AMI-Cleaned WER",        None),
-                "earnings22_test":           ("Earnings22 WER", None),
-                "gigaspeech_cleaned_test":   ("Gigaspeech-Cleaned WER", None),
-                "librispeech_test.clean":    ("LS Clean WER",   None),
-                "librispeech_test.other":    ("LS Other WER",   None),
-                "spgispeech_test":           ("SPGISpeech WER", None),
-                "voxpopuli_cleaned_aa_test": ("Voxpopuli-Cleaned-AA WER",  None),
+                "ami_cleaned_test": ("AMI-Cleaned WER", None),
+                "earnings22_test": ("Earnings22 WER", None),
+                "earnings22_cleaned_aa_chunked_test": (
+                    "Earnings22-Cleaned-AA-chunked WER",
+                    None,
+                ),
+                "gigaspeech_cleaned_test": ("Gigaspeech-Cleaned WER", None),
+                "librispeech_test.clean": ("LS Clean WER", None),
+                "librispeech_test.other": ("LS Other WER", None),
+                "spgispeech_test": ("SPGISpeech WER", None),
+                "voxpopuli_cleaned_aa_test": ("Voxpopuli-Cleaned-AA WER", None),
             },
         ),
         (
@@ -249,9 +349,9 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
             "_cleaned",
             "model,AMI WER,Gigaspeech WER,Voxpopuli WER",
             {
-                "ami_test":               ("AMI WER",        None),
-                "gigaspeech_test":        ("Gigaspeech WER", None),
-                "voxpopuli_test":         ("Voxpopuli WER",  None),
+                "ami_test": ("AMI WER", None),
+                "gigaspeech_test": ("Gigaspeech WER", None),
+                "voxpopuli_test": ("Voxpopuli WER", None),
             },
         ),
     ]
@@ -290,18 +390,22 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
                 else:
                     allowed_substrs.extend(col_map.keys())
         result_files = [
-            fp for fp in result_files
+            fp
+            for fp in result_files
             if any(substr in parse_filepath(fp)[1] for substr in allowed_substrs)
         ]
         if len(result_files) == 0:
-            raise ValueError(f"No result files found in {directory} matching families {families}")
+            raise ValueError(
+                f"No result files found in {directory} matching families {families}"
+            )
 
     # Compute WER results per dataset, and RTFx over all datasets
     from normalizer import data_utils  # deferred to avoid circular import
+
     results = {}
 
     for result_file in result_files:
-        manifest = read_manifest(result_file)
+        manifest = merge_chunked_manifest(read_manifest(result_file))
         model_id_of_file, dataset_id = parse_filepath(result_file)
 
         if language == "en":
@@ -323,7 +427,7 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
         # Use kaldialign batch_error_rate with merge_compounds=True so that
         # split compounds (e.g. "white paper" vs "whitepaper") count as
         # 0 errors in either direction.
-        refs_split  = [tuple(r.split()) for r in references]
+        refs_split = [tuple(r.split()) for r in references]
         preds_split = [tuple(p.split()) for p in predictions]
         r = batch_error_rate(refs_split, preds_split, merge_compounds=True)
         total_ins, total_del, total_sub = r["ins"], r["del"], r["sub"]
@@ -340,7 +444,13 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
             audio_length = inference_time = rtfx = None
 
         result_key = f"{model_id_of_file} | {dataset_id}"
-        results[result_key] = {"wer": wer, "audio_length": audio_length, "inference_time": inference_time, "rtfx": rtfx, **extra}
+        results[result_key] = {
+            "wer": wer,
+            "audio_length": audio_length,
+            "inference_time": inference_time,
+            "rtfx": rtfx,
+            **extra,
+        }
 
     if not csv_only:
         print("*" * 80)
@@ -411,43 +521,79 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
                 wer_vals = [v for v in wer_vals if v is not None]
                 if wer_vals:
                     avg = round(sum(wer_vals) / len(wer_vals), 2)
-                    label = original_model_id if original_model_id is not None else model_key.strip()
+                    label = (
+                        original_model_id
+                        if original_model_id is not None
+                        else model_key.strip()
+                    )
                     print(f"avg WER ({label}) = {avg}")
 
         print(header)
 
         for model_key in composite_wer:
-            csv_model_label = original_model_id if original_model_id is not None else model_key
-            wer_vals = {col: find_wer_in(model_key, col, col_map) for col in csv_columns}
-            wer_cols = [str(wer_vals[col]) if wer_vals[col] is not None else "" for col in csv_columns]
+            csv_model_label = (
+                original_model_id if original_model_id is not None else model_key
+            )
+            wer_vals = {
+                col: find_wer_in(model_key, col, col_map) for col in csv_columns
+            }
+            wer_cols = [
+                str(wer_vals[col]) if wer_vals[col] is not None else ""
+                for col in csv_columns
+            ]
 
             is_private = any(grp is not None for _lbl, grp in col_map.values())
             if is_private:
-                scripted_wers       = [v for _ds, (lbl, grp) in col_map.items()
-                                        if grp == "scripted"       and (v := wer_vals.get(lbl)) is not None]
-                conversational_wers = [v for _ds, (lbl, grp) in col_map.items()
-                                        if grp == "conversational" and (v := wer_vals.get(lbl)) is not None]
-                all_wers            = [v for v in wer_vals.values() if v is not None]
-                avg_overall        = round(sum(all_wers) / len(all_wers), 2)            if all_wers else ""
-                avg_scripted       = round(sum(scripted_wers) / len(scripted_wers), 2)  if scripted_wers else ""
-                avg_conv           = round(sum(conversational_wers) / len(conversational_wers), 2) if conversational_wers else ""
-                print(f"{csv_model_label},{avg_overall},{avg_scripted},{avg_conv}," + ",".join(wer_cols))
+                scripted_wers = [
+                    v
+                    for _ds, (lbl, grp) in col_map.items()
+                    if grp == "scripted" and (v := wer_vals.get(lbl)) is not None
+                ]
+                conversational_wers = [
+                    v
+                    for _ds, (lbl, grp) in col_map.items()
+                    if grp == "conversational" and (v := wer_vals.get(lbl)) is not None
+                ]
+                all_wers = [v for v in wer_vals.values() if v is not None]
+                avg_overall = (
+                    round(sum(all_wers) / len(all_wers), 2) if all_wers else ""
+                )
+                avg_scripted = (
+                    round(sum(scripted_wers) / len(scripted_wers), 2)
+                    if scripted_wers
+                    else ""
+                )
+                avg_conv = (
+                    round(sum(conversational_wers) / len(conversational_wers), 2)
+                    if conversational_wers
+                    else ""
+                )
+                print(
+                    f"{csv_model_label},{avg_overall},{avg_scripted},{avg_conv},"
+                    + ",".join(wer_cols)
+                )
             else:
-                n_prefix = len(header.split(',')) - 1 - len(csv_columns)
+                n_prefix = len(header.split(",")) - 1 - len(csv_columns)
                 if family_key == "public" or (family_key or "").startswith("ml_"):
                     family_audio = sum(
                         results[rk]["audio_length"]
                         for ds_substr in col_map
                         for rk in results
-                        if model_key.rstrip() in rk and ds_substr in rk and results[rk]["audio_length"] is not None
+                        if model_key.rstrip() in rk
+                        and ds_substr in rk
+                        and results[rk]["audio_length"] is not None
                     )
                     family_time = sum(
                         results[rk]["inference_time"]
                         for ds_substr in col_map
                         for rk in results
-                        if model_key.rstrip() in rk and ds_substr in rk and results[rk]["inference_time"] is not None
+                        if model_key.rstrip() in rk
+                        and ds_substr in rk
+                        and results[rk]["inference_time"] is not None
                     )
-                    rtfx_val = round(family_audio / family_time, 2) if family_time else ""
+                    rtfx_val = (
+                        round(family_audio / family_time, 2) if family_time else ""
+                    )
                     prefix_cols = [str(rtfx_val)] + [""] * (n_prefix - 1)
                 else:
                     prefix_cols = [""] * n_prefix
@@ -460,9 +606,11 @@ def score_results(directory: str, model_id: str = None, multilingual: bool = Fal
         if families is not None and family_key not in families:
             continue
         if family_key.startswith("ml_"):
-            family_name = family_key[len("ml_"):]  # "de", "fr", "it", "es", "pt"
+            family_name = family_key[len("ml_") :]  # "de", "fr", "it", "es", "pt"
         else:
-            family_name = family_key.capitalize()  # "Appen", "Dataocean", "Public", "Extra"
+            family_name = (
+                family_key.capitalize()
+            )  # "Appen", "Dataocean", "Public", "Extra"
         # Public block: print only if at least one public dataset key is found
         if presence_substr is None:
             has_public = any(ds_substr in all_dataset_ids for ds_substr in col_map)

--- a/omniasr/run_eval.py
+++ b/omniasr/run_eval.py
@@ -93,6 +93,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -100,6 +102,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -116,11 +120,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/omniasr/submit_jobs.sh
+++ b/omniasr/submit_jobs.sh
@@ -5,10 +5,31 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-omniasr}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 LANGUAGE="eng_Latn"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -16,12 +37,13 @@ MODEL_CONFIGS=(
     "omniASR_LLM_7B_v2"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 128"
@@ -36,9 +58,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -52,6 +75,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/phi/run_eval.py
+++ b/phi/run_eval.py
@@ -152,6 +152,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -159,6 +161,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -175,11 +179,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/phi/submit_jobs.sh
+++ b/phi/submit_jobs.sh
@@ -5,24 +5,46 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-phi4}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 NUM_BEAMS=1
 MAX_NEW_TOKENS=128
 USER_PROMPT="Transcribe the audio clip into text."
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
+
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
     "microsoft/Phi-4-multimodal-instruct"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 128"
     "gigaspeech_cleaned test 128"
     "voxpopuli_cleaned_aa test 128"
-    "earnings22 test 128"
+    "earnings22_cleaned_aa_chunked test 128 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 128"
     "librispeech test.other 128"
     "spgispeech test 128"
@@ -37,9 +59,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -91,7 +116,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/qwen/run_eval.py
+++ b/qwen/run_eval.py
@@ -81,6 +81,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -88,6 +90,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -104,11 +108,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/qwen/submit_jobs.sh
+++ b/qwen/submit_jobs.sh
@@ -5,10 +5,31 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-qwen}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=512  # matches the official qwen-asr package default
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -16,12 +37,13 @@ MODEL_CONFIGS=(
     "Qwen/Qwen3-ASR-1.7B"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 128"
     "gigaspeech_cleaned test 128"
     "voxpopuli_cleaned_aa test 128"
-    "earnings22 test 128"
+    "earnings22_cleaned_aa_chunked test 128 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 128"
     "librispeech test.other 128"
     "spgispeech test 128"
@@ -36,9 +58,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -52,6 +75,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/soundsgoodai/run_eval.py
+++ b/soundsgoodai/run_eval.py
@@ -268,12 +268,16 @@ def main(args: argparse.Namespace) -> None:
         fn_kwargs={"backend": backend},
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
         "predictions": [],
         "references": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     for result in tqdm(iter(dataset), desc="Samples..."):
         for key in all_results:
             all_results[key].append(result[key])
@@ -287,11 +291,22 @@ def main(args: argparse.Namespace) -> None:
         args.split,
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", manifest_path)
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(references=norm_refs, predictions=norm_preds)
     wer = round(100 * wer, 2)
     rtfx = round(

--- a/soundsgoodai/submit_jobs.sh
+++ b/soundsgoodai/submit_jobs.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-zipformer}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -15,12 +36,13 @@ MODEL_CONFIGS=(
     "soundsgoodai/Zipformer-cr-ctc-transducer-XL-290M 64"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -36,9 +58,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -51,6 +74,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 ICEFALL_PATH=/app/soundsgoodai/icefall
                 PYTHONPATH=\${ICEFALL_PATH}:\${ICEFALL_PATH}/egs/librispeech/ASR/zipformer:/app python run_eval.py \
                     --model_id=${MODEL_ID} \
@@ -87,7 +112,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/speechbrain/run_eval.py
+++ b/speechbrain/run_eval.py
@@ -161,6 +161,8 @@ def main(args):
         benchmark, batch_size=args.batch_size, batched=True, remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -168,6 +170,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -184,12 +188,23 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
     wer_metric = evaluate.load("wer")
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(
         references=norm_refs, predictions=norm_preds
     )

--- a/speechbrain/submit_jobs.sh
+++ b/speechbrain/submit_jobs.sh
@@ -5,24 +5,46 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-speechbrain}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "source speechbrain_class batch_size" ────────────────────────────
 # EncoderASR: wav2vec2 models
 # EncoderDecoderASR: conformer, crdnn, transformer models
 MODEL_CONFIGS=(
-    "speechbrain/asr-wav2vec2-librispeech EncoderASR 32"
+    # "speechbrain/asr-wav2vec2-librispeech EncoderASR 32"
     "speechbrain/asr-conformer-largescaleasr EncoderDecoderASR 32"
 )
 
-# ── Datasets: "name split" ────────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -38,7 +60,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
         # Adjust batch size for specific model/dataset combinations
         ACTUAL_BATCH_SIZE=$BATCH_SIZE
@@ -46,7 +69,7 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             ACTUAL_BATCH_SIZE=8
         fi
 
-        echo "Submitting job: source=${SOURCE} dataset=${DATASET} split=${SPLIT} batch_size=${ACTUAL_BATCH_SIZE}"
+        echo "Submitting job: source=${SOURCE} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${ACTUAL_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -59,6 +82,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --source=${SOURCE} \
                     --speechbrain_pretrained_class_name=${CLASS_NAME} \
@@ -95,7 +120,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${SOURCE}')

--- a/transformers/run_eval.py
+++ b/transformers/run_eval.py
@@ -393,6 +393,8 @@ def main(args):
         remove_columns=["audio"],
     )
 
+    is_chunked = data_utils.is_chunked_dataset(args.dataset_path)
+
     all_results = {
         "audio_length_s": [],
         "transcription_time_s": [],
@@ -400,6 +402,8 @@ def main(args):
         "references": [],
         "audio_filepath": [],
     }
+    if is_chunked:
+        all_results.update({key: [] for key in data_utils.CHUNK_METADATA_KEYS})
     result_iter = iter(dataset)
     for result in tqdm(result_iter, desc="Samples..."):
         for key in all_results:
@@ -417,11 +421,22 @@ def main(args):
         audio_length=all_results["audio_length_s"],
         transcription_time=all_results["transcription_time_s"],
         audio_filepaths=all_results["audio_filepath"],
+        extra_fields={key: all_results[key] for key in data_utils.CHUNK_METADATA_KEYS}
+        if is_chunked
+        else None,
     )
     print("Results saved at path:", os.path.abspath(manifest_path))
 
-    norm_refs = [data_utils.normalizer(r) for r in all_results["references"]]
-    norm_preds = [data_utils.normalizer(p) for p in all_results["predictions"]]
+    if is_chunked:
+        sessions = data_utils.merge_chunked_manifest(data_utils.read_manifest(manifest_path))
+        references = [session["text"] for session in sessions]
+        predictions = [session["pred_text"] for session in sessions]
+    else:
+        references = all_results["references"]
+        predictions = all_results["predictions"]
+
+    norm_refs = [data_utils.normalizer(r) for r in references]
+    norm_preds = [data_utils.normalizer(p) for p in predictions]
     wer = wer_metric.compute(references=norm_refs, predictions=norm_preds)
     wer = round(100 * wer, 2)
     rtfx = round(sum(all_results["audio_length_s"]) / sum(all_results["transcription_time_s"]), 2)

--- a/transformers/submit_jobs_cohere.sh
+++ b/transformers/submit_jobs_cohere.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=500
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "CohereLabs/cohere-transcribe-03-2026"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_crisper_whisper.sh
+++ b/transformers/submit_jobs_crisper_whisper.sh
@@ -6,22 +6,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "nyrahealth/CrisperWhisper"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 # Half the batch size of standard Whisper
 DATASET_CONFIGS=(
     "ami_cleaned test 32"
     "gigaspeech_cleaned test 32"
     "voxpopuli_cleaned_aa test 32"
-    "earnings22 test 32"
+    "earnings22_cleaned_aa_chunked test 32 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 32"
     "librispeech test.other 32"
     "spgispeech test 32"
@@ -36,13 +58,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -55,6 +78,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_data2vec.sh
+++ b/transformers/submit_jobs_data2vec.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
@@ -15,12 +36,13 @@ MODEL_IDs=(
     # "facebook/data2vec-audio-base-960h"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 8"
     "gigaspeech_cleaned test 8"
     "voxpopuli_cleaned_aa test 8"
-    "earnings22 test 8"
+    "earnings22_cleaned_aa_chunked test 8 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 8"
     "librispeech test.other 8"
     "spgispeech test 8"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -89,7 +114,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_glm_asr.sh
+++ b/transformers/submit_jobs_glm_asr.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=500
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "zai-org/GLM-ASR-Nano-2512"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_granite.sh
+++ b/transformers/submit_jobs_granite.sh
@@ -5,10 +5,31 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=200
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ────────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -16,13 +37,14 @@ MODEL_CONFIGS=(
     "ibm-granite/granite-speech-3.3-8b 64"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 # Note: batch_size in DATASET_CONFIGS is ignored here; MODEL_CONFIGS drives it
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -38,9 +60,10 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_hubert.sh
+++ b/transformers/submit_jobs_hubert.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
@@ -15,12 +36,13 @@ MODEL_IDs=(
     # "facebook/hubert-xlarge-ls960-ft"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -89,7 +114,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_mms.sh
+++ b/transformers/submit_jobs_mms.sh
@@ -5,21 +5,43 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "facebook/mms-1b-all"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 48"
     "gigaspeech_cleaned test 48"
     "voxpopuli_cleaned_aa test 48"
-    "earnings22 test 48"
+    "earnings22_cleaned_aa_chunked test 48 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 48"
     "librispeech test.other 48"
     "spgispeech test 48"
@@ -34,13 +56,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -53,6 +76,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_moonshine.sh
+++ b/transformers/submit_jobs_moonshine.sh
@@ -5,10 +5,31 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 DTYPE=float16
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ───────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -19,12 +40,13 @@ MODEL_CONFIGS=(
     # "usefulsensors/moonshine-base             1024"
 )
 
-# ── Datasets: "name split" ───────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -40,8 +62,9 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_nemotron.sh
+++ b/transformers/submit_jobs_nemotron.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ───────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -15,12 +36,13 @@ MODEL_CONFIGS=(
     "nvidia/nemotron-speech-streaming-en-0.6b  64"
 )
 
-# ── Datasets: "name split" ───────────────────────────────────────────────────
+# ── Datasets: "name split [dataset_path]" ─────────────────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -36,8 +58,9 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -50,6 +73,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -85,7 +110,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_qwen3asr.sh
+++ b/transformers/submit_jobs_qwen3asr.sh
@@ -5,10 +5,31 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=512  # matches the official qwen-asr package default
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
@@ -16,12 +37,13 @@ MODEL_IDs=(
     "Qwen/Qwen3-ASR-1.7B-hf"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 256"
     "gigaspeech_cleaned test 256"
     "voxpopuli_cleaned_aa test 256"
-    "earnings22 test 256"
+    "earnings22_cleaned_aa_chunked test 256 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 256"
     "librispeech test.other 256"
     "spgispeech test 256"
@@ -36,13 +58,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -55,6 +78,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -91,7 +116,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_vibevoice.sh
+++ b/transformers/submit_jobs_vibevoice.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=225  # 30s audio at 24000 Hz with 3200 compression
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "microsoft/VibeVoice-ASR-HF"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 32"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_voxtral.sh
+++ b/transformers/submit_jobs_voxtral.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=500
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
     "mistralai/Voxtral-Mini-3B-2507"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 32"
     "gigaspeech_cleaned test 32"
     "voxpopuli_cleaned_aa test 32"
-    "earnings22 test 32"
+    "earnings22_cleaned_aa_chunked test 32 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 32"
     "librispeech test.other 32"
     "spgispeech test 32"
@@ -35,9 +57,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -50,6 +73,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -86,7 +111,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_voxtral_24b.sh
+++ b/transformers/submit_jobs_voxtral_24b.sh
@@ -5,22 +5,44 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 MAX_NEW_TOKENS=500
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models ────────────────────────────────────────────────────────────────────
 MODEL_CONFIGS=(
     "mistralai/Voxtral-Small-24B-2507"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 32"
     "gigaspeech_cleaned test 32"
     "voxpopuli_cleaned_aa test 32"
-    "earnings22 test 32"
+    "earnings22_cleaned_aa_chunked test 32 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 32"
     "librispeech test.other 32"
     "spgispeech test 32"
@@ -35,9 +57,10 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -52,6 +75,8 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_voxtral_realtime.sh
+++ b/transformers/submit_jobs_voxtral_realtime.sh
@@ -5,21 +5,43 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
     "mistralai/Voxtral-Mini-4B-Realtime-2602"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 128"
     "gigaspeech_cleaned test 128"
     "voxpopuli_cleaned_aa test 128"
-    "earnings22 test 128"
+    "earnings22_cleaned_aa_chunked test 128 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 128"
     "librispeech test.other 128"
     "spgispeech test 128"
@@ -34,13 +56,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         # --env PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True" \
         # --env PYTORCH_ALLOC_CONF="expandable_segments:True" \
@@ -52,6 +75,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -88,7 +113,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_wav2vec2.sh
+++ b/transformers/submit_jobs_wav2vec2.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
@@ -17,12 +38,13 @@ MODEL_IDs=(
     # "facebook/wav2vec2-large-robust-ft-libri-960h"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 64"
     "gigaspeech_cleaned test 64"
     "voxpopuli_cleaned_aa test 64"
-    "earnings22 test 64"
+    "earnings22_cleaned_aa_chunked test 64 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 64"
     "librispeech test.other 64"
     "spgispeech test 64"
@@ -37,13 +59,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -56,6 +79,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -91,7 +116,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_wav2vec2_conformer.sh
+++ b/transformers/submit_jobs_wav2vec2_conformer.sh
@@ -5,9 +5,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models (comment / uncomment to select) ──────────────────────────────────
 MODEL_IDs=(
@@ -15,12 +36,13 @@ MODEL_IDs=(
     "facebook/wav2vec2-conformer-rope-large-960h-ft"
 )
 
-# ── Datasets: "name split batch_size" ────────────────────────────────────────
+# ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test 24"
     "gigaspeech_cleaned test 24"
     "voxpopuli_cleaned_aa test 24"
-    "earnings22 test 24"
+    "earnings22_cleaned_aa_chunked test 24 ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean 24"
     "librispeech test.other 24"
     "spgispeech test 24"
@@ -35,13 +57,14 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE <<< "$cfg"
+        read -r DATASET SPLIT EFFECTIVE_BATCH_SIZE DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
         if [[ -z "${EFFECTIVE_BATCH_SIZE}" ]]; then
             echo "ERROR: batch_size missing for '${DATASET} ${SPLIT}' in DATASET_CONFIGS" >&2
             exit 1
         fi
 
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${EFFECTIVE_BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -54,6 +77,8 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -90,7 +115,6 @@ for MODEL_ID in "${MODEL_IDs[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')

--- a/transformers/submit_jobs_whisper.sh
+++ b/transformers/submit_jobs_whisper.sh
@@ -6,9 +6,30 @@
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_h200}"      # HF bucket repo for saving results
-DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard}"
+DEFAULT_DATASET_PATH="${DEFAULT_DATASET_PATH:-hf-audio/open-asr-leaderboard}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Set USE_LOCAL_SCRIPT=1 to run your local run_eval.py instead of the version
+# committed to the Space (useful for iterating without pushing to the Space).
+USE_LOCAL_SCRIPT="${USE_LOCAL_SCRIPT:-1}"
+LOCAL_SCRIPT_INJECT=""
+if [[ "$USE_LOCAL_SCRIPT" == "1" ]]; then
+    RUN_EVAL_B64=$(base64 -w0 "${SCRIPT_DIR}/run_eval.py")
+    LOCAL_SCRIPT_INJECT="echo '${RUN_EVAL_B64}' | base64 -d > /app/run_eval.py &&"
+fi
+
+# Set USE_LOCAL_NORMALIZER=1 to inject your local normalizer/ package into the
+# job (so normalizer changes take effect without updating the HF Space).
+USE_LOCAL_NORMALIZER="${USE_LOCAL_NORMALIZER:-1}"
+LOCAL_NORMALIZER_INJECT=""
+if [[ "$USE_LOCAL_NORMALIZER" == "1" ]]; then
+    NORMALIZER_B64=$(tar --exclude='__pycache__' --exclude='*.pyc' -czf - -C "${REPO_ROOT}" normalizer | base64 -w0)
+    LOCAL_NORMALIZER_INJECT="echo '${NORMALIZER_B64}' | base64 -d | tar -xzf - -C /app &&"
+fi
 
 # ── Models: "model_id batch_size" ───────────────────────────────────────────
 MODEL_CONFIGS=(
@@ -26,12 +47,13 @@ MODEL_CONFIGS=(
     # "distil-whisper/distil-large-v3   64"
 )
 
-# ── Datasets: "name split" (comment / uncomment to select) ──────────────────
+# ── Datasets: "name split [dataset_path]" (comment / uncomment to select) ─────
+# dataset_path defaults to $DEFAULT_DATASET_PATH when omitted.
 DATASET_CONFIGS=(
     "ami_cleaned test"
     "gigaspeech_cleaned test"
     "voxpopuli_cleaned_aa test"
-    "earnings22 test"
+    "earnings22_cleaned_aa_chunked test ArtificialAnalysis/Earnings22-Cleaned-AA-chunked"
     "librispeech test.clean"
     "librispeech test.other"
     "spgispeech test"
@@ -48,8 +70,9 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
     echo "████████████████████████████████████████████████████████████████████████████████"
 
     for cfg in "${DATASET_CONFIGS[@]}"; do
-        read -r DATASET SPLIT <<< "$cfg"
-        echo "Submitting job: model=${MODEL_ID} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
+        read -r DATASET SPLIT DATASET_PATH <<< "$cfg"
+        DATASET_PATH="${DATASET_PATH:-$DEFAULT_DATASET_PATH}"
+        echo "Submitting job: model=${MODEL_ID} dataset_path=${DATASET_PATH} dataset=${DATASET} split=${SPLIT} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -62,6 +85,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
             --volume "hf://buckets/${RESULTS_BUCKET}:/results" \
             "hf.co/spaces/${SPACE}" \
             bash -c "
+                ${LOCAL_NORMALIZER_INJECT}
+                ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval.py \
                     --model_id=${MODEL_ID} \
                     --dataset_path=${DATASET_PATH} \
@@ -100,7 +125,6 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         echo "All ${ACTUAL} result files present."
     fi
 
-    REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
     PYTHONPATH="${REPO_ROOT}" python -c "
 from normalizer.eval_utils import score_results
 score_results('$(pwd)/results/${MODEL_FOLDER}', '${MODEL_ID}')


### PR DESCRIPTION
## Description

  Adds [`ArtificialAnalysis/Earnings22-Cleaned-AA-chunked`](https://huggingface.co/datasets/ArtificialAnalysis/Earnings22-Cleaned-AA-chunked) as an evaluation set, plus the generic support it needs.

  This set is structurally different from every other set on the leaderboard: it ships **one reference transcript per session, not per audio row**. It is 341 VAD-derived chunks (≤30 s) cut from 6 earnings calls, and the chunked repo carries no transcripts at all — the references live in the parent repo [`ArtificialAnalysis/Earnings22-Cleaned-AA`](https://huggingface.co/datasets/ArtificialAnalysis/Earnings22-Cleaned-AA), one per call. So WER has to be computed after reassembling each
  call from its chunks.

  Rather than special-casing this dataset, the PR adds a small generic path for "chunked" datasets:

  - `normalizer/data_utils.py`: a `CHUNKED_DATASETS` registry mapping a chunked dataset repo to the parent repo holding its transcripts. `load_data()` dispatches to `load_chunked_data()`, which fetches the audio (it isn't referenced by the metadata file) and attaches each chunk's parent transcript as `text`.
  - `normalizer/eval_utils.py`: `write_manifest()` gains an optional `extra_fields`, used to carry `parent_id` / `chunk_index` into the results manifest. `merge_chunked_manifest()` groups rows by `parent_id`, concatenates predictions in `chunk_index` order, and sums durations and times; `score_results()` applies it before scoring. Manifests without `parent_id` pass through untouched, so nothing changes for existing datasets.
  - Because the chunk metadata travels in the manifest, results stay order-independent — harnesses that re-sort by duration for batching (e.g. NeMo) work unmodified.
  - Wired through `nemo_asr/run_eval.py` and `transformers/run_eval.py`, and added as a column in the public CSV summary.

  ### How to run

  ```bash
  cd nemo_asr
  python run_eval.py \
      --model_id=nvidia/parakeet-tdt-0.6b-v3 \
      --dataset_path="ArtificialAnalysis/Earnings22-Cleaned-AA-chunked" \
      --dataset="earnings22_cleaned_aa_chunked" \
      --split="test" \
      --device=0 --batch_size=32 --max_eval_samples=-1
  ```

  `nemo_asr/run_parakeet.sh` now takes an optional third field per dataset config (`"name split [dataset_path]"`, defaulting to `hf-audio/open-asr-leaderboard`) and includes this set, so `bash run_parakeet.sh` covers it.

  ### Results

  | model | Earnings22 (current, original refs) | Earnings22-Cleaned-AA-chunked | RTFx |
  | -- | -- | -- | -- |
  | `nvidia/parakeet-tdt-0.6b-v2` | 10.78 | 6.79 | 1824 |
  | `nvidia/parakeet-tdt-0.6b-v3` | 10.77 | 5.86 | 1715 |

  Earnings22 column is the published number from `english_short_latest.csv`. RTFx is from local runs on a single A6000 at batch 32 — **not** leaderboard-grade (H200, max batch size, `torch.compile`); please re-measure via HF Jobs before publishing any throughput figure.

  ### Why this set is worth adding

  The cleaning matters more than the usual "another test set" argument. Controlled check — same audio, same model, same predictions, only the reference swapped (`parakeet-tdt-0.6b-v2`, on the 5 of 6 calls where AA did not also trim the audio):

  - vs. original Earnings22 transcripts: **11.31 %** WER
  - vs. AA cleaned transcripts: **7.42 %** WER

  So ~3.9 p.p. of what the leaderboard currently attributes to model error on Earnings22 is error in the reference transcript. That is consistent with AA's own reported 5.6 p.p. average across models.

  ### Notes for reviewers

  - **Aggregation.** `score_results()` pools errors across the 6 session rows (i.e. word-count weighted), which is what this repo does for every other set. AA instead documents an audio-duration-weighted average across sessions. Kept the repo's convention for consistency — happy to switch if you'd rather match AA exactly.
  - **Merging.** Chunks are non-overlapping and cover each call in order, so predictions are joined in `chunk_index` order with a single space; no overlap/dedup logic is needed.
  - **Partial runs.** `merge_chunked_manifest()` warns when a session's chunk indices aren't contiguous from 0 (e.g. under `--max_eval_samples`), since partial sessions silently inflate deletions.
  - This set is 6 calls, versus the 125-call original Earnings22 test set, so the two WER columns above are not a like-for-like subset. The controlled experiment is the clean evidence for the cleaning effect specifically.

  ## Type of change
  - [ ] New model
  - [x] New dataset
  - [ ] Bug fix
  - [x] New feature
  - [ ] Other

  ## New Dataset Checklist
  - [x] The dataset is hosted on the HF Hub with **just** the test set. (341 rows, `test` only; parent transcript repo is likewise `test` only, 6 rows. Both are hosted by Artificial Analysis.)
  - [ ] Create a new Bash script with one of the existing models.

    Added the dataset to the existing `nemo_asr/run_parakeet.sh` instead of creating a new script, since it's an additional set for existing models rather than a new model library. Let me know if you'd prefer a standalone script.
