### PR TITLE
Add bosonai/Qwen3-ASR-1.7B-hf-orze

### DIFF
--- a/transformers/submit_jobs_qwen3asr.sh
+++ b/transformers/submit_jobs_qwen3asr.sh
@@ -35,6 +35,7 @@ fi
 MODEL_IDs=(
     "Qwen/Qwen3-ASR-0.6B-hf"
     "Qwen/Qwen3-ASR-1.7B-hf"
+    "bosonai/Qwen3-ASR-1.7B-hf-orze"
 )
 
 # ── Datasets: "name split batch_size [dataset_path]" ──────────────────────────


### PR DESCRIPTION
## Description

Adds `bosonai/Qwen3-ASR-1.7B-hf-orze` to the existing native Transformers Qwen3-ASR HF Jobs submission script.

Model: https://huggingface.co/bosonai/Qwen3-ASR-1.7B-hf-orze

Exact-scored model revision: https://huggingface.co/bosonai/Qwen3-ASR-1.7B-hf-orze/commit/bce834cee3d106a9f0ec1ba98e96d995f13f59de

The checkpoint is a self-contained merged English specialization of `Qwen/Qwen3-ASR-1.7B-hf`. It requires no custom code and uses the existing `hf-audio/open-asr-leaderboard-transformers` evaluator. Its generation config uses deterministic beam size 4 and length penalty 0.7.

Exact A100 results with the same decoding settings on every dataset, rescored from the complete manifests with the leaderboard normalizer at `d1e99b25524814332d6868a5645e568670834cfb`:

| Dataset | WER |
|---|---:|
| AMI Cleaned | 7.98 |
| Earnings22 Cleaned AA chunked | 5.78 |
| GigaSpeech Cleaned | 7.18 |
| LibriSpeech test-clean | 1.19 |
| LibriSpeech test-other | 2.75 |
| SPGISpeech | 2.70 |
| VoxPopuli Cleaned AA | 2.73 |
| **Mean** | **4.33** |

RTFx: **74.01** on A100-80GB.

Compared with length penalty 0.8 on the same weights, length penalty 0.7 improved three independent, evaluation-only AppTek multi-accent call selections from 11.368 / 7.024 / 9.216 to 11.274 / 7.024 / 9.216 macro WER, and Switchboard test (first 1,000) from 9.18 to 9.15. No AppTek audio or private leaderboard data was used for training.

## Type of change

- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist

- [x] Results are reported in [`.eval_results/open_asr_leaderboard.yaml`](https://huggingface.co/bosonai/Qwen3-ASR-1.7B-hf-orze/blob/main/.eval_results/open_asr_leaderboard.yaml).
- [x] Uses the existing Transformers evaluation Space and batched `run_eval.py`.
- [x] Uses identical decoding hyperparameters across datasets (deterministic beam size 4, length penalty 0.7).
- [x] Exact public evaluation completed on A100-80GB with batch size 16.
- [x] Public WERs and RTFx are reported above and on the model card.
- [x] Total model size is approximately 2.04B parameters.
- [x] Training data are disclosed on the [model card](https://huggingface.co/bosonai/Qwen3-ASR-1.7B-hf-orze#training-disclosure).
- [x] Apache-2.0 license appears on the model card.

| License | Size (B) | # Languages | Encoder | Decoder | Training disclosure |
|---|---:|---:|---|---|---|
| apache-2.0 | 2.04 | 52 (English specialization evaluated) | Custom | Qwen3 | [model card](https://huggingface.co/bosonai/Qwen3-ASR-1.7B-hf-orze#training-disclosure) |
