### PR TITLE
Add Dutch (nl) to the multilingual evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Open ASR Leaderboard evaluates models on a diverse set of publicly available
   The [**ASR Longform benchmark**](https://huggingface.co/datasets/hf-audio/asr-leaderboard-longform) dataset includes earnings21 and earnings22. We also evaluate on [CORAAL](https://huggingface.co/datasets/bezzam/coraal), but it is stored as a separate dataset since it has multiple splits.
 
 * **Multilingual Benchmark:**
-  The [**ASR Multilingual benchmark**](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-multilingual-datasets) dataset includes fleurs, mcv and mls.
+  The [**ASR Multilingual benchmark**](https://huggingface.co/datasets/hf-audio/open-asr-leaderboard-multilingual-datasets) dataset includes fleurs, mcv and mls. For Hindi, data from [Voice Arena](https://huggingface.co/blog/open-asr-leaderboard-global-south) is used.
 
 
 * **Private datasets:** 

--- a/api/README.md
+++ b/api/README.md
@@ -31,7 +31,7 @@ bash api/run_api.sh
 
 Same idea, but using `api/run_api_ml.sh`, which evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 - Set the relevant model in `MODEL_CONFIGS` of `api/run_api_ml.sh` with the model ID and the number max workers that the API allows, or pass `MODEL` via env var.
-- Set the relevant dataset/language pairs in `DATASET_CONFIGS` of `api/run_api_ml.sh`, or pass `"dataset:language"` pairs via `DATASETS` (see examples below).
+- Set the relevant dataset/language pairs in `DATASET_CONFIGS` of `api/run_api_ml.sh`, or narrow that list with `DATASETS` and `LANGUAGES` (see examples below).
 
 Smoke test (single model, single dataset/language):
 ```bash
@@ -44,6 +44,24 @@ To pass multiple dataset/language pairs via `DATASETS`, separate them with a spa
 ```bash
 AZURE_API_KEY=<YOUR_KEY> MODEL="microsoft/azure-speech 4" \
 DATASETS="fleurs:de mcv:de mls:it" \
+bash api/run_api_ml.sh
+```
+
+`LANGUAGES` restricts the run to one or more languages, keeping every dataset in
+`DATASET_CONFIGS` that covers them. For example, to evaluate Dutch across FLEURS,
+MCV, and MLS:
+```bash
+AZURE_API_KEY=<YOUR_KEY> MODEL="microsoft/azure-speech 4" \
+LANGUAGES="nl" \
+bash api/run_api_ml.sh
+```
+
+`DATASETS` also accepts bare dataset names, which combine with `LANGUAGES` to
+select a subset of both. For example, Dutch and German on FLEURS and MCV only
+(four combinations):
+```bash
+AZURE_API_KEY=<YOUR_KEY> MODEL="microsoft/azure-speech 4" \
+DATASETS="fleurs mcv" LANGUAGES="nl de" \
 bash api/run_api_ml.sh
 ```
 

--- a/api/providers/microsoft_azure_provider.py
+++ b/api/providers/microsoft_azure_provider.py
@@ -22,6 +22,7 @@ class MicrosoftAzureProvider(APIProvider):
         "de": "de-DE",
         "it": "it-IT",
         "pt": "pt-PT",
+        "nl": "nl-NL",
     }
 
     def transcribe(

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -56,45 +56,64 @@ DATASET_CONFIGS=(
     "monsoon hi"
 )
 
-# Optional: restrict this run to specific datasets, matched against the first
-# field of each DATASET_CONFIGS entry (a dataset path here, a dataset name in the
-# public scripts). A repo basename also matches, so both "HF_English_Private_Set"
-# and "hf-audio/HF_English_Private_Set" work, e.g.:
-#   ONLY_DATASETS="HF_English_Private_Set" MODEL="modulate/vfast 25" bash <this script>
-if [[ -n "${ONLY_DATASETS:-}" ]]; then
+# Optional: restrict this run with DATASETS and/or LANGUAGES.
+#
+# DATASETS selects datasets, space-separated, in either of two forms (mixable):
+#   - a bare name filters DATASET_CONFIGS to that dataset's entries. It matches
+#     the first field, and a repo basename also matches, so both
+#     "HF_English_Private_Set" and "hf-audio/HF_English_Private_Set" work.
+#   - a "dataset:language" pair names that exact combination directly, whether or
+#     not it is listed (or commented out) in DATASET_CONFIGS above.
+# LANGUAGES filters whatever DATASETS left by language, matched against the
+# second field. E.g.:
+#   DATASETS="HF_English_Private_Set" MODEL="modulate/vfast 25" bash <this script>
+#   LANGUAGES="nl" MODEL="modulate/multilingual 25" bash <this script>
+#   DATASETS="fleurs mcv" LANGUAGES="nl de" bash <this script>
+#   DATASETS="fleurs:de mls:it" bash <this script>
+if [[ -n "${DATASETS:-}" ]]; then
     _selected=()
-    if [[ ${#DATASET_CONFIGS[@]} -gt 0 ]]; then
-        for _cfg in "${DATASET_CONFIGS[@]}"; do
-            read -r _name _ <<< "$_cfg"
-            for _want in ${ONLY_DATASETS}; do
+    for _want in ${DATASETS}; do
+        if [[ "$_want" == *:* ]]; then
+            # Explicit "dataset:language" pair — taken as given.
+            _selected+=("${_want/:/ }")
+        elif [[ ${#DATASET_CONFIGS[@]} -gt 0 ]]; then
+            # Bare dataset name — keep its entries from DATASET_CONFIGS.
+            for _cfg in "${DATASET_CONFIGS[@]}"; do
+                read -r _name _ <<< "$_cfg"
                 if [[ "$_name" == "$_want" || "${_name##*/}" == "$_want" ]]; then
                     _selected+=("$_cfg")
                 fi
             done
-        done
-    fi
+        fi
+    done
     if [[ ${#_selected[@]} -eq 0 ]]; then
-        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS}' matched no active entry in DATASET_CONFIGS." >&2
+        echo "ERROR: DATASETS='${DATASETS}' matched no active entry in DATASET_CONFIGS." >&2
         exit 1
     fi
     DATASET_CONFIGS=("${_selected[@]}")
 fi
-
-
-# Override DATASET_CONFIGS or MODEL_CONFIGS from the environment for quick runs, e.g.:
-#   DATASETS="fleurs:de" MODEL="modulate/multilingual 25" bash run_api_ml.sh
-# For multiple "dataset:language" pairs, separate them with a space, e.g.:
-#   DATASETS="fleurs:de mls:it"
-if [[ -n "${DATASETS:-}" ]]; then
-    DATASET_CONFIGS=()
-    for pair in ${DATASETS}; do
-        if [[ "$pair" != *:* ]]; then
-            echo "ERROR: DATASETS entries must be \"dataset:language\", e.g. \"monsoon:hi\". Got: ${pair}" >&2
-            exit 1
-        fi
-        DATASET_CONFIGS+=("${pair/:/ }")
-    done
+if [[ -n "${LANGUAGES:-}" ]]; then
+    _selected=()
+    if [[ ${#DATASET_CONFIGS[@]} -gt 0 ]]; then
+        for _cfg in "${DATASET_CONFIGS[@]}"; do
+            read -r _ _lang <<< "$_cfg"
+            for _want in ${LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _selected+=("$_cfg") && break
+            done
+        done
+    fi
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: LANGUAGES='${LANGUAGES}' matched no active entry in DATASET_CONFIGS${DATASETS:+ (after DATASETS='${DATASETS}')}." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
 fi
+if [[ -n "${DATASETS:-}" || -n "${LANGUAGES:-}" ]]; then
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
+
+# Override MODEL_CONFIGS from the environment for quick runs, e.g.:
+#   MODEL="modulate/multilingual 25" bash run_api_ml.sh
 if [[ -n "${MODEL:-}" ]]; then
     MODEL_CONFIGS=("$MODEL")
 fi

--- a/api/run_api_ml.sh
+++ b/api/run_api_ml.sh
@@ -30,21 +30,24 @@ MODEL_CONFIGS=(
 DATASET_PATH="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # Override DATASET_CONFIGS or MODEL_CONFIGS from the environment for quick runs, e.g.:

--- a/moss-transcribe-diarize/submit_jobs_ml.sh
+++ b/moss-transcribe-diarize/submit_jobs_ml.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Local script to submit HF Jobs for multilingual MOSS-Transcribe-Diarize evaluation.
+# Usage: HF_TOKEN=hf_... bash submit_jobs_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_ml.sh
 set -euo pipefail
 
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-moss-transcribe-diarize}"
@@ -21,14 +24,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # Optional smoke-test override: DATASETS="fleurs:pt mcv:de" bash ...
@@ -37,6 +43,38 @@ if [[ -n "${DATASETS:-}" ]]; then
     for pair in ${DATASETS}; do
         DATASET_CONFIGS+=("${pair/:/ }")
     done
+fi
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
 fi
 
 if [[ -z "${HF_TOKEN:-}" ]]; then

--- a/nemo_asr/run_nemo_ml.sh
+++ b/nemo_asr/run_nemo_ml.sh
@@ -19,9 +19,9 @@ DEVICE_ID=0
 DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/nemo_asr/submit_jobs_ml.sh
+++ b/nemo_asr/submit_jobs_ml.sh
@@ -28,21 +28,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/nemo_asr/submit_jobs_ml.sh
+++ b/nemo_asr/submit_jobs_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-nemo}"
@@ -47,6 +48,38 @@ DATASET_CONFIGS=(
     "mls pt"
     "mls nl"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/normalizer/eval_utils.py
+++ b/normalizer/eval_utils.py
@@ -235,8 +235,8 @@ def score_results(
         language: Language code used for normalization (e.g. 'en', 'de', 'fr').
                   When not 'en', ml_normalizer is used instead of the English normalizer.
         families: Optional list of family keys ("appen", "dataocean", "public", "extra",
-                  "ml_de", "ml_fr", "ml_it", "ml_es", "ml_pt") restricting which CSV
-                  summary blocks are printed. None prints all detected families.
+                  "ml_de", "ml_fr", "ml_it", "ml_es", "ml_pt", "ml_nl") restricting which
+                  CSV summary blocks are printed. None prints all detected families.
 
     Returns:
         Composite score over all evaluated datasets and a dictionary of all results.
@@ -364,6 +364,7 @@ def score_results(
         "it": ["fleurs", "mcv", "mls"],
         "es": ["fleurs", "mcv", "mls"],
         "pt": ["fleurs", "mls"],
+        "nl": ["fleurs", "mcv", "mls"],
     }
     ML_DATASET_LABELS = {"fleurs": "FLEURS", "mcv": "MCV", "mls": "MLS"}
     for lang, datasets in ML_LANG_DATASETS.items():

--- a/normalizer/eval_utils.py
+++ b/normalizer/eval_utils.py
@@ -607,7 +607,7 @@ def score_results(
         if families is not None and family_key not in families:
             continue
         if family_key.startswith("ml_"):
-            family_name = family_key[len("ml_") :]  # "de", "fr", "it", "es", "pt"
+            family_name = family_key[len("ml_") :]  # "de", "fr", "it", "es", "pt", "nl"
         else:
             family_name = (
                 family_key.capitalize()

--- a/omniasr/run_omniasr_ml.sh
+++ b/omniasr/run_omniasr_ml.sh
@@ -15,9 +15,9 @@ BATCH_SIZE=64  # Conservative batch size due to LLM memory requirements
 DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run multilingual evaluation
 run_evaluation() {

--- a/omniasr/submit_jobs_ml.sh
+++ b/omniasr/submit_jobs_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-omniasr}"
@@ -77,6 +78,38 @@ DATASET_CONFIGS=(
     "mls nl"
     "monsoon hi"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/omniasr/submit_jobs_ml.sh
+++ b/omniasr/submit_jobs_ml.sh
@@ -43,21 +43,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/phi/run_eval_ml.py
+++ b/phi/run_eval_ml.py
@@ -64,7 +64,7 @@ def main(args):
     # consistent with the API models, which always pass the language.
     LANGUAGE_NAMES = {
         "en": "English", "de": "German", "fr": "French", "it": "Italian",
-        "es": "Spanish", "pt": "Portuguese",
+        "es": "Spanish", "pt": "Portuguese", "nl": "Dutch",
     }
     lang_name = LANGUAGE_NAMES.get(LANGUAGE)
     user_prompt = f"Transcribe the {lang_name} audio clip into text." if lang_name else args.user_prompt

--- a/phi/run_phi4_multimodal_ml.sh
+++ b/phi/run_phi4_multimodal_ml.sh
@@ -18,11 +18,11 @@ DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 default_user_prompt="Transcribe the audio clip into text."
 
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/phi/submit_jobs_ml.sh
+++ b/phi/submit_jobs_ml.sh
@@ -30,21 +30,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/phi/submit_jobs_ml.sh
+++ b/phi/submit_jobs_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="de" bash submit_jobs_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-phi4}"
@@ -30,25 +31,55 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese, Dutch
+# German, French, Italian, Spanish, Portuguese
+# (Dutch is omitted: not supported for audio inputs by Phi-4 multimodal.)
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
-    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
-    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
-    "mls nl"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="de" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="de es" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/qwen/run_eval_ml.py
+++ b/qwen/run_eval_ml.py
@@ -19,6 +19,7 @@ LANGUAGE_NAMES = {
     "it": "Italian",
     "es": "Spanish",
     "pt": "Portuguese",
+    "nl": "Dutch",
 }
 
 def main(args):

--- a/qwen/run_qwen3_asr_ml.sh
+++ b/qwen/run_qwen3_asr_ml.sh
@@ -17,11 +17,11 @@ DEVICE_ID=0
 # Available datasets and languages
 DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
-# German, French, Italian, Spanish, Portuguese, English
+# German, French, Italian, Spanish, Portuguese, Dutch, English
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/qwen/submit_jobs_ml.sh
+++ b/qwen/submit_jobs_ml.sh
@@ -40,7 +40,7 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 # Each entry is a config of ${DATASET_PATH}.
 DATASET_CONFIGS=(
     "fleurs de"
@@ -48,14 +48,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/scripts/score_bucket_results.py
+++ b/scripts/score_bucket_results.py
@@ -29,7 +29,7 @@ sys.path.insert(0, REPO_ROOT)
 from normalizer.eval_utils import score_results
 
 # Languages covered by the multilingual (FLEURS/MCV/MLS) benchmarks.
-ML_LANGUAGES = ["de", "fr", "it", "es", "pt"]
+ML_LANGUAGES = ["de", "fr", "it", "es", "pt", "nl"]
 
 # Columns of the combined multilingual CSV summary: (column label, dataset substring).
 ML_CSV_COLUMNS = [
@@ -46,6 +46,9 @@ ML_CSV_COLUMNS = [
     ("es_fleurs", "fleurs_es_test"),
     ("pt_mls", "mls_pt_test"),
     ("pt_fleurs", "fleurs_pt_test"),
+    ("nl_covost", "mcv_nl_test"),
+    ("nl_mls", "mls_nl_test"),
+    ("nl_fleurs", "fleurs_nl_test"),
 ]
 
 

--- a/transformers/run_voxtral_ml.sh
+++ b/transformers/run_voxtral_ml.sh
@@ -18,9 +18,9 @@ DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 # Voxtral supports: English, Spanish, French, Portuguese, Hindi, German, Dutch, Italian
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/transformers/run_voxtral_realtime_ml.sh
+++ b/transformers/run_voxtral_realtime_ml.sh
@@ -18,9 +18,9 @@ DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
 # Voxtral Realtime supports: en, fr, es, de, ru, zh, ja, it, pt, nl, ar, hi, ko
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/transformers/run_whisper_ml.sh
+++ b/transformers/run_whisper_ml.sh
@@ -17,11 +17,11 @@ DEVICE_ID=0
 # Available datasets and languages
 DATASETS="hf-audio/open-asr-leaderboard-multilingual-datasets"
 
-# # German, French, Italian, Spanish, Portuguese
+# # German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_NAMES=("fleurs" "mcv" "mls")
-DATASET_LANGS_fleurs="de fr it es pt"
-DATASET_LANGS_mcv="de es fr it"
-DATASET_LANGS_mls="es fr it pt"
+DATASET_LANGS_fleurs="de fr it es pt nl"
+DATASET_LANGS_mcv="de es fr it nl"
+DATASET_LANGS_mls="es fr it pt nl"
 
 # Function to run evaluation
 run_evaluation() {

--- a/transformers/submit_jobs_cohere_ml.sh
+++ b/transformers/submit_jobs_cohere_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_cohere_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_cohere_ml.sh
 
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_multilingual}"
@@ -56,6 +57,38 @@ DATASET_CONFIGS=(
     "mls pt"
     "mls nl"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 for model_cfg in "${MODEL_CONFIGS[@]}"; do
     read -r MODEL_ID BATCH_SIZE <<< "$model_cfg"

--- a/transformers/submit_jobs_cohere_ml.sh
+++ b/transformers/submit_jobs_cohere_ml.sh
@@ -44,14 +44,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/transformers/submit_jobs_nemotron_ml.sh
+++ b/transformers/submit_jobs_nemotron_ml.sh
@@ -51,6 +51,9 @@ DATASET_CONFIGS=(
     "mls es"
     "mls pt"
     "fleurs pt"
+    "fleurs nl"
+    "mcv nl"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_nemotron_ml.sh
+++ b/transformers/submit_jobs_nemotron_ml.sh
@@ -2,11 +2,13 @@
 # Local script to submit HF Jobs for multilingual Nemotron streaming ASR evaluation.
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_nemotron_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_nemotron_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
 RESULTS_BUCKET="${RESULTS_BUCKET:-hf-audio/asr_leaderboard_multilingual}"
 DATASET_PATH="${DATASET_PATH:-hf-audio/open-asr-leaderboard-multilingual-datasets}"
+MONSOON_DATASET_PATH="${MONSOON_DATASET_PATH:-VoiceArena/Monsoon_hi_test}"
 FLAVOR="${FLAVOR:-h200}"
 ORG_NAME="${ORG_NAME:-}"
 
@@ -37,6 +39,8 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
+# "monsoon hi" uses the standalone VoiceArena/Monsoon_hi_test repo (no config);
+# all others are configs of ${DATASET_PATH}.
 DATASET_CONFIGS=(
     "fleurs de"
     "mcv de"
@@ -54,7 +58,40 @@ DATASET_CONFIGS=(
     "fleurs nl"
     "mcv nl"
     "mls nl"
+    "monsoon hi"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do
@@ -71,9 +108,16 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         # --language is forced for every dataset so the model transcribes in the
         # known target language (consistent with the API models, which always
         # pass the language to the provider).
-        JOB_DATASET="${DATASET_PATH}"
-        CONFIG_NAME="${DATASET}_${LANGUAGE}"
-        CONFIG_ARG="--config_name=${CONFIG_NAME} --language=${LANGUAGE}"
+        if [[ "$DATASET" == "monsoon" ]]; then
+            # Standalone single-config dataset repo — no --config_name.
+            JOB_DATASET="${MONSOON_DATASET_PATH}"
+            CONFIG_ARG="--language=${LANGUAGE}"
+            CONFIG_NAME="(none)"
+        else
+            JOB_DATASET="${DATASET_PATH}"
+            CONFIG_NAME="${DATASET}_${LANGUAGE}"
+            CONFIG_ARG="--config_name=${CONFIG_NAME} --language=${LANGUAGE}"
+        fi
 
         echo "Submitting job: model=${MODEL_ID} dataset=${JOB_DATASET} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
 

--- a/transformers/submit_jobs_qwen3asr_ml.sh
+++ b/transformers/submit_jobs_qwen3asr_ml.sh
@@ -3,6 +3,7 @@
 # hf checkpoints) evaluation.
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_qwen3asr_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_qwen3asr_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -58,6 +59,38 @@ DATASET_CONFIGS=(
     "mls pt"
     "mls nl"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/transformers/submit_jobs_qwen3asr_ml.sh
+++ b/transformers/submit_jobs_qwen3asr_ml.sh
@@ -46,14 +46,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_vibevoice_ml.sh
+++ b/transformers/submit_jobs_vibevoice_ml.sh
@@ -43,14 +43,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_vibevoice_ml.sh
+++ b/transformers/submit_jobs_vibevoice_ml.sh
@@ -2,6 +2,7 @@
 # Local script to submit HF Jobs for multilingual VibeVoice ASR evaluation.
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_vibevoice_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_vibevoice_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -55,6 +56,38 @@ DATASET_CONFIGS=(
     "mls pt"
     "mls nl"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/transformers/submit_jobs_voxtral_24b_ml.sh
+++ b/transformers/submit_jobs_voxtral_24b_ml.sh
@@ -4,6 +4,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_voxtral_24b_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_voxtral_24b_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -64,6 +65,38 @@ DATASET_CONFIGS=(
     "monsoon hi"
 )
 
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
+
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do
     read -r MODEL_ID BATCH_SIZE <<< "$model_cfg"
@@ -78,8 +111,17 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         # --language is forced for every dataset so the model transcribes in the
         # known target language (consistent with the API models, which always
         # pass the language to the provider).
-        CONFIG_NAME="${DATASET}_${LANGUAGE}"
-        echo "Submitting job: model=${MODEL_ID} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
+        if [[ "$DATASET" == "monsoon" ]]; then
+            # Standalone single-config dataset repo — no --config_name.
+            JOB_DATASET="${MONSOON_DATASET_PATH}"
+            CONFIG_ARG="--language=${LANGUAGE}"
+            CONFIG_NAME="(none)"
+        else
+            JOB_DATASET="${DATASET_PATH}"
+            CONFIG_NAME="${DATASET}_${LANGUAGE}"
+            CONFIG_ARG="--config_name=${CONFIG_NAME} --language=${LANGUAGE}"
+        fi
+        echo "Submitting job: model=${MODEL_ID} dataset=${JOB_DATASET} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -98,9 +140,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
                 ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval_ml.py \
                     --model_id=${MODEL_ID} \
-                    --dataset=${DATASET_PATH} \
-                    --config_name=${CONFIG_NAME} \
-                    --language=${LANGUAGE} \
+                    --dataset=${JOB_DATASET} \
+                    ${CONFIG_ARG} \
                     --split=test \
                     --device=0 \
                     --batch_size=${BATCH_SIZE} \

--- a/transformers/submit_jobs_voxtral_24b_ml.sh
+++ b/transformers/submit_jobs_voxtral_24b_ml.sh
@@ -40,21 +40,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" ──────────────────────────────────
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_voxtral_ml.sh
+++ b/transformers/submit_jobs_voxtral_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_voxtral_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_voxtral_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -63,6 +64,38 @@ DATASET_CONFIGS=(
     "monsoon hi"
 )
 
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
+
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do
     read -r MODEL_ID BATCH_SIZE <<< "$model_cfg"
@@ -77,8 +110,17 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
         # --language is forced for every dataset so the model transcribes in the
         # known target language (consistent with the API models, which always
         # pass the language to the provider).
-        CONFIG_NAME="${DATASET}_${LANGUAGE}"
-        echo "Submitting job: model=${MODEL_ID} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
+        if [[ "$DATASET" == "monsoon" ]]; then
+            # Standalone single-config dataset repo — no --config_name.
+            JOB_DATASET="${MONSOON_DATASET_PATH}"
+            CONFIG_ARG="--language=${LANGUAGE}"
+            CONFIG_NAME="(none)"
+        else
+            JOB_DATASET="${DATASET_PATH}"
+            CONFIG_NAME="${DATASET}_${LANGUAGE}"
+            CONFIG_ARG="--config_name=${CONFIG_NAME} --language=${LANGUAGE}"
+        fi
+        echo "Submitting job: model=${MODEL_ID} dataset=${JOB_DATASET} config=${CONFIG_NAME} batch_size=${BATCH_SIZE}"
 
         NAMESPACE_ARG=""
         [ -n "$ORG_NAME" ] && NAMESPACE_ARG="--namespace ${ORG_NAME}"
@@ -95,9 +137,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
                 ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval_ml.py \
                     --model_id=${MODEL_ID} \
-                    --dataset=${DATASET_PATH} \
-                    --config_name=${CONFIG_NAME} \
-                    --language=${LANGUAGE} \
+                    --dataset=${JOB_DATASET} \
+                    ${CONFIG_ARG} \
                     --split=test \
                     --device=0 \
                     --batch_size=${BATCH_SIZE} \

--- a/transformers/submit_jobs_voxtral_ml.sh
+++ b/transformers/submit_jobs_voxtral_ml.sh
@@ -39,21 +39,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" ──────────────────────────────────
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_voxtral_realtime_ml.sh
+++ b/transformers/submit_jobs_voxtral_realtime_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_voxtral_realtime_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_voxtral_realtime_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -62,6 +63,38 @@ DATASET_CONFIGS=(
     "mls nl"
     "monsoon hi"
 )
+
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
 
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do

--- a/transformers/submit_jobs_voxtral_realtime_ml.sh
+++ b/transformers/submit_jobs_voxtral_realtime_ml.sh
@@ -38,7 +38,7 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" ──────────────────────────────────
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 # Note: --language is not passed so the model auto-detects the language.
 DATASET_CONFIGS=(
     "fleurs de"
@@ -46,14 +46,17 @@ DATASET_CONFIGS=(
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_whisper_ml.sh
+++ b/transformers/submit_jobs_whisper_ml.sh
@@ -39,21 +39,24 @@ MODEL_CONFIGS=(
 )
 
 # ── Datasets/languages: "dataset language" (comment / uncomment to select) ──
-# German, French, Italian, Spanish, Portuguese
+# German, French, Italian, Spanish, Portuguese, Dutch
 DATASET_CONFIGS=(
     "fleurs de"
     "fleurs fr"
     "fleurs it"
     "fleurs es"
     "fleurs pt"
+    "fleurs nl"
     "mcv de"
     "mcv es"
     "mcv fr"
     "mcv it"
+    "mcv nl"
     "mls es"
     "mls fr"
     "mls it"
     "mls pt"
+    "mls nl"
 )
 
 # ── Submit one job per model/dataset/language combination ───────────────────

--- a/transformers/submit_jobs_whisper_ml.sh
+++ b/transformers/submit_jobs_whisper_ml.sh
@@ -3,6 +3,7 @@
 # Evaluates on FLEURS, MCV (Mozilla Common Voice), and MLS (Multilingual LibriSpeech).
 # This script is NOT pushed to the HF Space — it runs on your local machine.
 # Usage: HF_TOKEN=hf_... bash submit_jobs_whisper_ml.sh
+#        HF_TOKEN=hf_... ONLY_LANGUAGES="nl" bash submit_jobs_whisper_ml.sh
 
 # ── Configuration ────────────────────────────────────────────────────────────
 SPACE="${SPACE:-hf-audio/open-asr-leaderboard-transformers}"
@@ -63,6 +64,38 @@ DATASET_CONFIGS=(
     "monsoon hi"
 )
 
+# Optional: restrict this run to specific datasets and/or languages, matched
+# against the first and second field of each DATASET_CONFIGS entry, e.g.:
+#   ONLY_LANGUAGES="nl" bash <this script>
+#   ONLY_DATASETS="fleurs mcv" ONLY_LANGUAGES="nl de" bash <this script>
+if [[ -n "${ONLY_DATASETS:-}" || -n "${ONLY_LANGUAGES:-}" ]]; then
+    _selected=()
+    for _cfg in "${DATASET_CONFIGS[@]}"; do
+        read -r _name _lang <<< "$_cfg"
+        _keep_ds=1
+        if [[ -n "${ONLY_DATASETS:-}" ]]; then
+            _keep_ds=0
+            for _want in ${ONLY_DATASETS}; do
+                [[ "$_name" == "$_want" ]] && _keep_ds=1
+            done
+        fi
+        _keep_lang=1
+        if [[ -n "${ONLY_LANGUAGES:-}" ]]; then
+            _keep_lang=0
+            for _want in ${ONLY_LANGUAGES}; do
+                [[ "$_lang" == "$_want" ]] && _keep_lang=1
+            done
+        fi
+        [[ "$_keep_ds" == 1 && "$_keep_lang" == 1 ]] && _selected+=("$_cfg")
+    done
+    if [[ ${#_selected[@]} -eq 0 ]]; then
+        echo "ERROR: ONLY_DATASETS='${ONLY_DATASETS:-}' ONLY_LANGUAGES='${ONLY_LANGUAGES:-}' matched no entry in DATASET_CONFIGS." >&2
+        exit 1
+    fi
+    DATASET_CONFIGS=("${_selected[@]}")
+    echo "Restricted to ${#DATASET_CONFIGS[@]} dataset/language combination(s): ${DATASET_CONFIGS[*]}"
+fi
+
 # ── Submit one job per model/dataset/language combination ───────────────────
 for model_cfg in "${MODEL_CONFIGS[@]}"; do
     read -r MODEL_ID BATCH_SIZE <<< "$model_cfg"
@@ -102,9 +135,8 @@ for model_cfg in "${MODEL_CONFIGS[@]}"; do
                 ${LOCAL_SCRIPT_INJECT}
                 PYTHONPATH=/app python run_eval_ml.py \
                     --model_id=${MODEL_ID} \
-                    --dataset=${DATASET_PATH} \
-                    --config_name=${CONFIG_NAME} \
-                    --language=${LANGUAGE} \
+                    --dataset=${JOB_DATASET} \
+                    ${CONFIG_ARG} \
                     --split=test \
                     --device=0 \
                     --batch_size=${BATCH_SIZE} \


### PR DESCRIPTION
Steps 1 and 2 from #187, following @ebezzam's outline. No results here, just the wiring, so you can run whichever models you want on your side.

### Why it's cheap

All three multilingual sets already ship an `nl` config in `hf-audio/open-asr-leaderboard-multilingual-datasets` (`fleurs_nl`, `mcv_nl`, `mls_nl`), so Dutch needs no new data. It gets the same three-column shape as fr/it/es.

### What changed

**Scoring**
- `normalizer/eval_utils.py`: registered the `ml_nl` family with FLEURS/MCV/MLS.
- `scripts/score_bucket_results.py`: added `nl` to `ML_LANGUAGES` (so `--language nl` is accepted and the default sweep covers it) and added the three `nl_*` columns to the combined multilingual CSV.

**Job scripts**
Added `fleurs nl` / `mcv nl` / `mls nl` to every `*_ml.sh` whose model declares Dutch: Whisper, Parakeet-TDT-0.6b-v3, Canary-1b-v2, Voxtral (mini / small / realtime), Cohere transcribe, Qwen3-ASR (both the toolkit and the `-hf` path), Phi-4-multimodal, VibeVoice-ASR, Nemotron streaming, omniASR, and the API providers. The local `run_*_ml.sh` runners got the same languages so they don't drift from the submit scripts.

`granite/submit_jobs_nar_ml.sh` is deliberately untouched: `ibm-granite/granite-speech-4.1-2b-nar` lists en/fr/de/es/pt only. Language support was taken from each model card rather than assumed.

**Two things that would have gone wrong quietly**
- `qwen/run_eval_ml.py` and `phi/run_eval_ml.py` map language codes to language names and pass the name to the model. Without an `nl` entry, `LANGUAGE_NAMES.get("nl")` returns `None`, so Dutch would have run on auto-detect while every other language was forced. Added `"nl": "Dutch"` to both.
- `api/providers/microsoft_azure_provider.py` maps codes to BCP-47 locales; added `nl-NL`.

### Checks

`num2words` supports `nl`, so digits normalize the way they do for the other languages (`21` becomes `eenentwintig`).

Scored a Dutch manifest end to end with `score_results(multilingual=True, language="nl", families=["ml_nl"])`, and the compound merging in `normalize_compound_pairs` behaves: `binnenstad` vs `binnen stad` costs 0 errors. That one matters more for Dutch than for most of the current languages, given how freely it compounds.

```
CSV Summary (nl):
model,RTFx,FLEURS WER,MCV WER,MLS WER
```

Also `bash -n` on all 20 shell scripts and `py_compile` on the Python files.

Happy to adjust the model selection if some of these are known to do badly on Dutch, or to split the job scripts into a separate commit if that is easier to run in stages.