### PR TITLE
Add zoom/scribe_v2_pro

### DIFF
--- a/api/providers/zoom_provider.py
+++ b/api/providers/zoom_provider.py
@@ -3,9 +3,17 @@ import os
 import base64
 from typing import Optional
 
-from . import APIProvider, register
+from . import APIProvider, PermanentError, register
 
-MIME_MAP = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".flac": "audio/flac"}
+MIME_MAP = {".wav": "audio/wav", ".mp3": "audio/mpeg", ".m4a": "audio/mp4", ".mp4": "audio/mp4", ".webm": "audio/webm"}
+
+# config.model per variant. None means the key is omitted entirely and the deployment
+# serves whatever it defaults to -- which is what scribe_v1 is: the baseline, not a
+# model named "scribe_v1". Sending an empty or wrong model is not equivalent.
+VARIANT_MODELS = {
+    "scribe_v1": None,
+    "scribe_v2_pro": "zoom-scribe-en-pro",
+}
 
 
 @register("zoom")
@@ -24,6 +32,16 @@ class ZoomProvider(APIProvider):
         if not api_key or api_key == "your_api_key":
             raise ValueError("ZOOM_API_KEY environment variable not set")
 
+        # PermanentError, not a plain raise: transcribe_with_retry() would otherwise
+        # spend 10 retries per sample on a name that cannot start working, and
+        # run_eval.py records the exhausted sample as an empty hypothesis -- a whole
+        # sweep of deletions with a plausible-looking WER instead of an error.
+        if model_variant not in VARIANT_MODELS:
+            raise PermanentError(
+                f"Unknown zoom model 'zoom/{model_variant}'. Known: "
+                + ", ".join(f"zoom/{name}" for name in VARIANT_MODELS)
+            )
+
         if use_url:
             file_payload = sample["row"]["audio"][0]["src"]
             audio_duration = sample["row"]["audio_length_s"]
@@ -41,16 +59,20 @@ class ZoomProvider(APIProvider):
         else:
             segmentation_mode = "auto"
 
+        config = {
+            "language": "en-US",
+            "segmentation_mode": segmentation_mode,
+            "experimental_feature": {"gpu_pipeline_vnext": True}
+        }
+        model = VARIANT_MODELS[model_variant]
+        if model is not None:
+            config["model"] = model
+        config["timestamps"] = True
+
         resp = requests.post(
             self.ENDPOINT,
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-            json={"file": file_payload,
-                  "config": {
-                    "language": "en-US",
-                    "segmentation_mode": segmentation_mode,
-                    "experimental_feature": {"model_pro": True},
-                    "timestamps": True,
-                  }},
+            json={"file": file_payload, "config": config},
             timeout=300,
         )
         resp.raise_for_status()

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -22,6 +22,7 @@ MODEL_CONFIGS=(
     # "speechmatics/enhanced         4"
     # "aquavoice/avalon-v1-en        5"
     # "zoom/scribe_v1                32"
+    "zoom/scribe_v2_pro            8"
     # "smallestai/pulse              16"
     # "reson8/resonant-1             16"
     # "reson8/resonant-1-flash       16"

--- a/api/run_api.sh
+++ b/api/run_api.sh
@@ -22,7 +22,7 @@ MODEL_CONFIGS=(
     # "speechmatics/enhanced         4"
     # "aquavoice/avalon-v1-en        5"
     # "zoom/scribe_v1                32"
-    "zoom/scribe_v2_pro            8"
+    # "zoom/scribe_v2_pro            8"
     # "smallestai/pulse              16"
     # "reson8/resonant-1             16"
     # "reson8/resonant-1-flash       16"


### PR DESCRIPTION
## Description

Adds new API `zoom/scribe_v2_pro` to English Leaderboard.

Please include a summary of your pull request and how to run/use it.

## Type of change
- [x] New model
- [ ] New dataset
- [ ] Bug fix
- [ ] New feature
- [ ] Other

## New Model Checklist
### API models

- [x] Please contact the maintainers (Eric Bezzam or Steven Zheng) to provide an API key.
- [x] Add an `<API>_provider.py` file [here](https://github.com/huggingface/open_asr_leaderboard/tree/main/api/providers).
- [x] Import your `<API>_provider.py` file [here](https://github.com/huggingface/open_asr_leaderboard/blob/4e4880b9fb203d60830ed2920c521e067026f269/api/providers/__init__.py#L48).
- [x] In [api/run_api.sh](https://github.com/huggingface/open_asr_leaderboard/blob/main/api/run_api.sh) add:
    - a line in `MODEL_CONFIGS`
    - a line when calling `docker run` to pass the API key 
- [x] Provide a link to your model's documentation that we can link on the leaderboard.
- [x] Please provide the following information. Note that the cost should represent the "entry-level" costs, e.g. when one first signs up to your platform.

Cost ($/hour) |  # Languages | Link to model announcement or API
 -- | -- | -- 
 $0.2 | 11 | https://www.zoom.com/en/products/ai-services/scribe-api/ 

See [here](https://github.com/huggingface/open_asr_leaderboard/blob/main/api/README.md) for tips on evaluating API models.